### PR TITLE
Implemented MRP evaluation with FunctionApprox interface.

### DIFF
--- a/rl/approximate_dynamic_programming.py
+++ b/rl/approximate_dynamic_programming.py
@@ -1,0 +1,37 @@
+from typing import Iterator, Mapping, TypeVar
+
+from rl.function_approx import FunctionApprox
+from rl.iterate import converged, iterate
+from rl.markov_process import FiniteMarkovRewardProcess
+
+S = TypeVar('S')
+
+# A representation of a value function for a finite MDP with states of
+# type S
+V = Mapping[S, float]
+
+
+def evaluate_mrp(mrp: FiniteMarkovRewardProcess[S],
+                 gamma: float,
+                 approx_0: FunctionApprox[S]) -> Iterator[FunctionApprox[S]]:
+    '''Iteratively calculate the value function for the give Markov reward
+    process, using the given FunctionApprox to approximate the value
+    function at each step.
+
+    '''
+    def update(v: FunctionApprox[S]) -> FunctionApprox[S]:
+        vs = v.evaluate(mrp.non_terminal_states)
+        updated = mrp.reward_function_vec + gamma *\
+            mrp.get_transition_matrix().dot(vs)
+        return v.update(zip(mrp.states(), updated))
+
+    return iterate(update, approx_0)
+
+
+def evaluate_mrp_result(mrp: FiniteMarkovRewardProcess[S],
+                        gamma: float,
+                        approx_0: FunctionApprox[S]) -> FunctionApprox[S]:
+    def done(a, b):
+        return a.within(b, tolerance=0.0001)
+
+    return converged(evaluate_mrp(mrp, gamma, approx_0), done=done)

--- a/rl/dynamic_programming.py
+++ b/rl/dynamic_programming.py
@@ -1,13 +1,12 @@
-from typing import Mapping, Iterator, TypeVar, Tuple, Dict, Sequence
+import numpy as np
 import operator
+from typing import Mapping, Iterator, TypeVar, Tuple, Dict, Sequence
 
 from rl.iterate import converged, iterate
 from rl.markov_decision_process import (FiniteMarkovDecisionProcess,
                                         FiniteMarkovRewardProcess,
                                         FinitePolicy)
 from rl.distribution import FiniteDistribution, Categorical, Constant, Choose
-import numpy as np
-
 
 A = TypeVar('A')
 S = TypeVar('S')

--- a/rl/function_approx.py
+++ b/rl/function_approx.py
@@ -50,7 +50,11 @@ class Dynamic(FunctionApprox[X]):
         return np.array([self.values_map[x] for x in x_values_seq])
 
     def update(self, xy_vals_seq: Sequence[Tuple[X, float]]) -> Dynamic[X]:
-        return replace(self, values_map=dict(xy_vals_seq))
+        new_map = self.values_map.copy()
+        for x, y in xy_vals_seq:
+            new_map[x] = y
+
+        return replace(self, values_map=new_map)
 
     def within(self, other: FunctionApprox[X], tolerance: float) -> bool:
         if isinstance(other, Dynamic):

--- a/rl/function_approx.py
+++ b/rl/function_approx.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
-from abc import ABC
-from typing import Sequence, Mapping, Tuple, TypeVar, Callable, List, Dict, \
-    Generic, Optional
-import numpy as np
+
+from abc import ABC, abstractmethod
+from collections import defaultdict
 from dataclasses import dataclass, replace, field
 from more_itertools import pairwise
-from collections import defaultdict
+import numpy as np
+from typing import Sequence, Mapping, Tuple, TypeVar, Callable, List, Dict, \
+    Generic, Optional
 
 X = TypeVar('X')
 SMALL_NUM = 1e-6
@@ -13,17 +14,51 @@ SMALL_NUM = 1e-6
 
 class FunctionApprox(ABC, Generic[X]):
 
+    @abstractmethod
     def evaluate(self, x_values_seq: Sequence[X]) -> np.ndarray:
         pass
 
     def __call__(self, x_value: X) -> float:
         return self.evaluate([x_value]).item()
 
+    @abstractmethod
     def update(
         self,
         xy_vals_seq: Sequence[Tuple[X, float]]
     ) -> FunctionApprox[X]:
         pass
+
+    @abstractmethod
+    def within(self, other: FunctionApprox[X], tolerance: float) -> bool:
+        '''Is this function approximation is within a given tolerance of
+        another approximation of the same type?
+
+        '''
+        pass
+
+
+@dataclass(frozen=True)
+class Dynamic(FunctionApprox[X]):
+    '''A FunctionApprox that works exactly the same as exact dynamic
+    programming.
+
+    '''
+
+    values_map: Mapping[X, float]
+
+    def evaluate(self, x_values_seq: Sequence[X]) -> np.ndarray:
+        return np.array([self.values_map[x] for x in x_values_seq])
+
+    def update(self, xy_vals_seq: Sequence[Tuple[X, float]]) -> Dynamic[X]:
+        return replace(self, values_map=dict(xy_vals_seq))
+
+    def within(self, other: FunctionApprox[X], tolerance: float) -> bool:
+        if isinstance(other, Dynamic):
+            return\
+                all(abs(self.values_map[s] - other.values_map[s]) <= tolerance
+                    for s in self.values_map)
+        else:
+            return False
 
 
 @dataclass(frozen=True)
@@ -34,7 +69,7 @@ class Tabular(FunctionApprox[X]):
         field(default_factory=lambda: defaultdict(int))
 
     def evaluate(self, x_values_seq: Sequence[X]) -> np.ndarray:
-        return np.array([self.values_map[x] for x in x_values_seq])
+        return np.array(self.values_map[x] for x in x_values_seq)
 
     def update(
         self,
@@ -51,6 +86,14 @@ class Tabular(FunctionApprox[X]):
             values_map=values_map,
             counts_map=counts_map
         )
+
+    def within(self, other: FunctionApprox[X], tolerance: float) -> bool:
+        if isinstance(other, Tabular):
+            return\
+                all(abs(self.values_map[s] - other.values_map[s]) <= tolerance
+                    for s in self.values_map)
+        else:
+            return False
 
 
 @dataclass(frozen=True)
@@ -102,6 +145,9 @@ class Weights:
             adam_cache2=new_adam_cache2,
         )
 
+    def within(self, other: Weights[X], tolerance: float) -> bool:
+        return np.all(np.abs(self.weights - other.weights) <= tolerance).item()
+
 
 @dataclass(frozen=True)
 class LinearFunctionApprox(FunctionApprox[X]):
@@ -135,6 +181,12 @@ class LinearFunctionApprox(FunctionApprox[X]):
             self.get_feature_values(x_values_seq),
             self.weights.weights
         )
+
+    def within(self, other: FunctionApprox[X], tolerance: float) -> bool:
+        if isinstance(other, LinearFunctionApprox):
+            return self.weights.within(other.weights)
+        else:
+            return False
 
     def regularized_loss_gradient(
         self,
@@ -249,6 +301,13 @@ class DNNApprox(FunctionApprox[X]):
 
     def evaluate(self, x_values_seq: Sequence[X]) -> np.ndarray:
         return self.forward_propagation(x_values_seq)[-1][:, 0]
+
+    def within(self, other: FunctionApprox[X], tolerance: float) -> bool:
+        if isinstance(other, DNNApprox):
+            return all(w1.within(w2)
+                       for w1, w2 in zip(self.weights, other.weights))
+        else:
+            return False
 
     def backward_propagation(
         self,

--- a/rl/test_approximate_dynamic_programming.py
+++ b/rl/test_approximate_dynamic_programming.py
@@ -1,0 +1,54 @@
+import unittest
+
+from rl.approximate_dynamic_programming import evaluate_mrp_result
+from rl.distribution import Categorical
+from rl.finite_horizon import (finite_horizon_MRP, evaluate,
+                               unwrap_finite_horizon_MRP, WithTime)
+from rl.function_approx import Dynamic
+from rl.markov_process import FiniteMarkovRewardProcess
+
+
+class FlipFlop(FiniteMarkovRewardProcess[bool]):
+    '''A version of FlipFlop implemented with the FiniteMarkovProcess
+    machinery.
+
+    '''
+
+    def __init__(self, p: float):
+        transition_reward_map = {
+            b: Categorical({(not b, 2.0): p, (b, 1.0): 1 - p})
+            for b in (True, False)
+        }
+        super().__init__(transition_reward_map)
+
+
+class TestEvaluate(unittest.TestCase):
+    def setUp(self):
+        self.finite_flip_flop = FlipFlop(0.7)
+
+    def test_evaluate_mrp(self):
+        start = Dynamic({s: 0.0 for s in self.finite_flip_flop.states()})
+        v = evaluate_mrp_result(self.finite_flip_flop,
+                                gamma=0.99,
+                                approx_0=start)
+
+        self.assertEqual(len(v.values_map), 2)
+
+        for s in v.values_map:
+            self.assertLess(abs(v(s) - 170), 0.1)
+
+    def test_compare_to_backward_induction(self):
+        finite_horizon = finite_horizon_MRP(self.finite_flip_flop, 10)
+
+        start = Dynamic({s: 0.0 for s in finite_horizon.states()})
+        v = evaluate_mrp_result(finite_horizon, gamma=1, approx_0=start)
+        self.assertEqual(len(v.values_map), 20)
+
+        finite_v =\
+            list(evaluate(unwrap_finite_horizon_MRP(finite_horizon), gamma=1))
+
+        for time in range(0, 10):
+            self.assertAlmostEqual(v(WithTime(state=True, time=time)),
+                                   finite_v[time][True])
+            self.assertAlmostEqual(v(WithTime(state=False, time=time)),
+                                   finite_v[time][False])

--- a/rl/test_dynamic_programming.py
+++ b/rl/test_dynamic_programming.py
@@ -1,0 +1,49 @@
+import unittest
+
+from rl.distribution import Categorical
+from rl.dynamic_programming import evaluate_mrp_result
+from rl.finite_horizon import (finite_horizon_MRP, evaluate,
+                               unwrap_finite_horizon_MRP, WithTime)
+from rl.markov_process import FiniteMarkovRewardProcess
+
+
+class FlipFlop(FiniteMarkovRewardProcess[bool]):
+    '''A version of FlipFlop implemented with the FiniteMarkovProcess
+    machinery.
+
+    '''
+
+    def __init__(self, p: float):
+        transition_reward_map = {
+            b: Categorical({(not b, 2.0): p, (b, 1.0): 1 - p})
+            for b in (True, False)
+        }
+        super().__init__(transition_reward_map)
+
+
+class TestEvaluate(unittest.TestCase):
+    def setUp(self):
+        self.finite_flip_flop = FlipFlop(0.7)
+
+    def test_evaluate_mrp(self):
+        v = evaluate_mrp_result(self.finite_flip_flop, gamma=0.99)
+
+        self.assertEqual(len(v), 2)
+
+        for s in v:
+            self.assertLess(abs(v[s] - 170), 0.1)
+
+    def test_compare_to_backward_induction(self):
+        finite_horizon = finite_horizon_MRP(self.finite_flip_flop, 10)
+
+        v = evaluate_mrp_result(finite_horizon, gamma=1)
+        self.assertEqual(len(v), 20)
+
+        finite_v =\
+            list(evaluate(unwrap_finite_horizon_MRP(finite_horizon), gamma=1))
+
+        for time in range(0, 10):
+            self.assertAlmostEqual(v[WithTime(state=True, time=time)],
+                                   finite_v[time][True])
+            self.assertAlmostEqual(v[WithTime(state=False, time=time)],
+                                   finite_v[time][False])

--- a/rl/test_function_approx.py
+++ b/rl/test_function_approx.py
@@ -1,0 +1,42 @@
+import unittest
+import numpy as np
+
+from rl.function_approx import (Dynamic)
+
+
+class TestDynamic(unittest.TestCase):
+    def setUp(self):
+        self.dynamic_0 = Dynamic(values_map={0: 0.0, 1: 0.0, 2: 0.0})
+        self.dynamic_almost_0 = Dynamic(values_map={0: 0.01, 1: 0.01, 2: 0.01})
+
+        self.dynamic_1 = Dynamic(values_map={0: 1.0, 1: 2.0, 2: 3.0})
+        self.dynamic_almost_1 = Dynamic(values_map={0: 1.01, 1: 2.01, 2: 3.01})
+
+    def test_update(self):
+        updated = self.dynamic_0.update([(0, 1.0), (1, 2.0), (2, 3.0)])
+        self.assertEqual(self.dynamic_1, updated)
+
+    def test_evaluate(self):
+        np.testing.assert_array_almost_equal(
+            self.dynamic_0.evaluate([0, 1, 2]),
+            np.array([0.0, 0.0, 0.0])
+        )
+
+        np.testing.assert_array_almost_equal(
+            self.dynamic_1.evaluate([0, 1, 2]),
+            np.array([1.0, 2.0, 3.0])
+        )
+
+    def test_call(self):
+        for i in range(0, 3):
+            self.assertEqual(self.dynamic_0(i), 0.0)
+            self.assertEqual(self.dynamic_1(i), float(i + 1))
+
+    def test_within(self):
+        self.assertTrue(self.dynamic_0.within(self.dynamic_0, tolerance=0.0))
+        self.assertTrue(self.dynamic_0.within(self.dynamic_almost_0,
+                                              tolerance=0.011))
+
+        self.assertTrue(self.dynamic_1.within(self.dynamic_1, tolerance=0.0))
+        self.assertTrue(self.dynamic_1.within(self.dynamic_almost_1,
+                                              tolerance=0.011))

--- a/rl/test_function_approx.py
+++ b/rl/test_function_approx.py
@@ -16,6 +16,10 @@ class TestDynamic(unittest.TestCase):
         updated = self.dynamic_0.update([(0, 1.0), (1, 2.0), (2, 3.0)])
         self.assertEqual(self.dynamic_1, updated)
 
+        partially_updated = self.dynamic_0.update([(1, 3.0)])
+        expected = {0: 0.0, 1: 3.0, 2: 0.0}
+        self.assertEqual(partially_updated, Dynamic(values_map=expected))
+
     def test_evaluate(self):
         np.testing.assert_array_almost_equal(
             self.dynamic_0.evaluate([0, 1, 2]),


### PR DESCRIPTION
Three core changes to do this:

  1. A within method on FunctionApprox to know when we've converged.
  2. A Dynamic class inheriting from FunctionApprox, which behaves exactly like the table in dynamic programming algorithms. (Better name?)
  3. An implementation of evaluate_mrp that uses FunctionApprox instead of an array.

I wrote some simple tests using Dynamic, but the implementation of evaluate_mrp should work with *any* FunctionApprox. We should probably come up with more tests for this and, really, more tests for the rest of our code...