### PR TITLE
Set up infrastructure for referencing chapters and sections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,61 @@ Once you have Nix installed, run `nix-shell` to get access to Pandoc, LaTeX and 
 
 [install]: https://nixos.org/download.html
 
-## Development
+## Generating PDFs
 
 Once inside the Nix shell, you'll have access to Pandoc and you'll be able to generate PDFs with XeTeX. The `to-pdf` script does this for a single Markdown file:
 
 ```
-[nix-shell:~/Documents/RL-book]$ bin/to-pdf example
+[nix-shell:~/Documents/RL-book]$ bin/to-pdf chapter0/chapter0.md
+Converting chapter0/chapter0.md to chapter0/chapter0.pdf
 ```
 
-(Note that it's `example` and not `example.md`.)
+You can also generate the entire book to a file called `book.pdf`:
 
-Over time, I'm going to add more functionality to this system, depending on exactly what we need. I'll probably set up a way to generate PDF/Word/etc documents using `nix-build` as well.
+```
+[nix-shell:~/Documents/RL-book]$ bin/to-pdf
+Combining
+chapter0/chapter0.md
+chapter2/chapter2.md
+chapter3/chapter3.md
+chapter4/chapter4.md
+chapter5/chapter5.md
+into book.pdf
+```
+
+Note that this can take a little while (10–20 seconds for chapters 0–5).
+
+### Cross-references
+
+We can define labels for chapters and headings:
+
+```
+# Overview {#sec:overview}
+
+## Learning Reinforcement Learning {#sec:learning-rl}
+```
+
+Because of limitations with the system I'm using for managing internal references, labels for sections *and* chapters always have to start with `sec:`.
+
+Once you have defined a label for a section or chapter, you can reference its number as follows:
+
+```
+Take a look at Chapter [-@sec:mdp].
+```
+
+> Take a look at Chapter 3.
+
+For sections, you can also use:
+
+```
+Take a look at [@sec:learning-rl].
+```
+
+> Take a look at sec. 1.
+
+(The `[-@sec:foo]` syntax drops the "sec. " text.)
+
+For references across chapters to render correctly, you have to compile the entire book PDF (following the instructions above).
 
 ## Working with Python and venv
 

--- a/bin/to-pdf
+++ b/bin/to-pdf
@@ -1,11 +1,41 @@
 #!/usr/bin/env bash
 
-FILE=$1
-
-if [[ ${FILE: -3} == ".md" ]]
+if [[ $# -eq 0 ]]
 then
-    FILE=${FILE%.*}
+    args=(chapter*/chapter*.md)
+else
+    args="$@"
 fi
 
-echo "Converting $FILE.md to $FILE.pdf"
-pandoc -t pdf --pdf-engine=xelatex -o "$1.pdf" --template latex.template "$1.md"
+if [[ $# -eq 1 ]]
+then
+    out="${1%.*}.pdf"
+else
+    out="book.pdf"
+fi
+
+for path in "${args[@]}"
+do
+    names+=("${path%.*}.md")
+done
+
+if [[ $# -eq 1 ]]
+then
+    echo "Converting ${names[@]} to $out"
+else
+    echo "Combining"
+    for path in "${names[@]}"
+    do
+        echo $path
+    done
+    echo "into $out"
+fi
+
+pandoc -t pdf \
+       -o "$out" \
+       -F pandoc-crossref \
+       -M chapters \
+       --pdf-engine=xelatex \
+       --template templates/latex.template \
+       --top-level-division=chapter \
+       "${names[@]}"

--- a/chapter0/chapter0.md
+++ b/chapter0/chapter0.md
@@ -1,6 +1,6 @@
-# Overview
+# Overview {#sec:overview}
 
-## Learning Reinforcement Learning
+## Learning Reinforcement Learning {#sec:learning-rl}
 
 Reinforcement Learning (RL) is emerging as a viable and powerful technique for solving a variety of complex business problems across industries that involve optimal decisioning under uncertainty. Although RL is classified as a branch of Machine Learning (ML), it tends to be viewed and treated quite differently from other branches of ML (Supervised and Unsupervised Learning). Indeed, **RL seems to hold the key to unlocking the promise of AI** – machines that adapt their decisions to vagaries in observed information, while continuously steering towards the optimal outcome. It’s penetration in high-profile problems like self-driving cars, robotics and strategy games points to a future where RL algorithms will have decisioning abilities far superior to humans.
 

--- a/chapter2/chapter2.md
+++ b/chapter2/chapter2.md
@@ -1,5 +1,5 @@
 
-# Markov Processes
+# Markov Processes {#sec:mp}
 
 This book is about "Sequential Decisioning under Sequential Uncertainty". In this chapter, we will ignore the "sequential decisioning" aspect and focus just on the "sequential uncertainty" aspect.
 

--- a/chapter3/chapter3.md
+++ b/chapter3/chapter3.md
@@ -1,4 +1,4 @@
-# Markov Decision Processes
+# Markov Decision Processes {#sec:mdp}
 
 We've said before that this book is about "sequential decisioning" under "sequential uncertainty". In the previous chapter, we covered the "sequential uncertainty" aspect with the framework of Markov Processes, and we extended the framework to also incoporate the notion of uncertain "Reward" each time we make a state transition - we called this extended framework Markov Reward Processes. However, this framework had no notion of "sequential decisioning". In this chapter, we will further extend the framework of Markov Reward Processes to incorporate the notion of "sequential decisioning", formally known as Markov Decision Processes. Before we step into the formalism of Markov Decision Processes, let us develop some intuition and motivation for the need to have such a framework - to handle sequential decisioning. Let's do this by re-visiting the simple inventory example we covered in the previous chapter.
 

--- a/chapter4/chapter4.md
+++ b/chapter4/chapter4.md
@@ -1,4 +1,4 @@
-# Dynamic Programming Algorithms
+# Dynamic Programming Algorithms {#sec:dp}
 
 As a reminder, much of this book is about algorithms to solve the MDP Control problem, i.e., to compute the Optimal Value Function (and an associated Optimal Policy). We will also cover algorithms for the MDP Prediction problem, i.e., to compute the Value Function when the agent executes a fixed policy $\pi$ (which, as we know from the previous chapter, is the same as the $\pi$-implied MRP problem). Our typical approach will be to first cover algorithms to solve the Prediction problem before covering algorithms to solve the Control problem - not just because Prediction is a key component in solving the Control problem, but also because it helps understand the key aspects of the techniques employed in the Control algorithm in the simpler setting of Prediction.
 

--- a/chapter5/chapter5.md
+++ b/chapter5/chapter5.md
@@ -1,4 +1,4 @@
-# Function Approximation and Approximate Dynamic Programming
+# Function Approximation and Approximate Dynamic Programming {#sec:func-approx}
 
 In the previous chapter, we covered Dynamic Programming algorithms where the MDP is specified in the form of a finite data structure and the Value Function is represented as a finite "table" of states and values. These Dynamic Programming algorithms swept through all states in each iteration to update the value function. But when the state space is large (as is the case in real-world applications), these Dynamic Programming algorithm won't work because:
 

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  texlive = pkgs.texlive.combine {
+  tex-packages = {
     inherit (pkgs.texlive)
       scheme-medium
       footmisc
@@ -12,12 +12,37 @@ let
       noto;
   };
 
-  fonts = pkgs.makeFontsConf {
-    fontDirectories = [ pkgs.eb-garamond pkgs.tex-gyre.pagella ];
-  };
+  python-packages = ps: with ps;
+    [ graphviz
+      ipython
+      jedi
+      jupyter
+      matplotlib
+      mypy
+      numpy
+      pandas
+      pylint
+      scipy
+    ];
 
-  pythonWithPackages = python.withPackages (ps:
-    with ps; [ graphviz ipython jedi jupyter matplotlib mypy numpy pandas pylint scipy ]);
+  # Applications and utilties for buidling the book
+  packages = with pkgs;
+    [ fontconfig
+      graphviz
+      pandoc
+      watchexec
+
+      haskellPackages.pandoc-crossref
+
+      (texlive.combine tex-packages)
+    ];
+
+  fonts = with pkgs;
+    [ eb-garamond
+      tex-gyre.pagella
+    ];
+
+  pythonWithPackages = python.withPackages python-packages;
 
   system-packages =
     if pkgs.stdenv.isDarwin
@@ -28,14 +53,9 @@ pkgs.stdenv.mkDerivation {
   name = "RL-book";
   src = ./.;
 
-  buildInputs = [
-    texlive
+  buildInputs = with pkgs; packages ++ system-packages;
 
-    pkgs.fontconfig
-    pkgs.graphviz
-    pkgs.pandoc
-    pkgs.watchexec
-  ] ++ system-packages;
-
-  FONTCONFIG_FILE = fonts;
+  FONTCONFIG_FILE = pkgs.makeFontsConf {
+    fontDirectories = fonts;
+  };
 }

--- a/templates/latex.template
+++ b/templates/latex.template
@@ -1,5 +1,5 @@
 %!TEX TS-program = xelatex
-\documentclass[11pt]{scrartcl}  
+\documentclass[11pt]{scrbook}
 
 % -- We are in swanky unicode, XeTeX land, and must now import these packages:
 \usepackage{fontspec,xltxtra,xunicode}


### PR DESCRIPTION
We can define labels for chapters and headings:

```
# Overview {#sec:overview}

Take a look at Chapter [-@sec:mdp] and [@sec:learning-rl].

## Learning Reinforcement Learning {#sec:learning-rl}
```

Because of limitations with the system I'm using for managing internal references, labels for sections *and* chapters always have to start with `sec:`.

Once you have defined a label for a section or chapter, you can reference its number as follows:

```
Take a look at Chapter [-@sec:mdp].
```

> Take a look at Chapter 3.

For sections, you can also use:

```
Take a look at [@sec:learning-rl].
```

> Take a look at sec. 1.

(The `[-@sec:foo]` syntax drops the "sec. " text.)

To have references across chapters work correctly, we have to compile *the entire book* all at once. I've extended the `to-pdf` script so that running it with no arguments from the top-level directory of the repo will generate a file called `book.pdf`:

```
[nix-shell:~/Programming/rl-book]$ bin/to-pdf
Combining
chapter0/chapter0.md
chapter2/chapter2.md
chapter3/chapter3.md
chapter4/chapter4.md
chapter5/chapter5.md
into book.pdf
[WARNING] Could not fetch resource './chapter4/dynamic_pricing.png': replacing image with description
[WARNING] Could not fetch resource './chapter5/rmse.png': replacing image with description
```

This PDF will have the entire book and all the references should work, but it's a bit slow (a bit under 10 seconds on my computer right now).