### PR TITLE
New returns implementation.

### DIFF
--- a/rl/markov_decision_process.py
+++ b/rl/markov_decision_process.py
@@ -134,7 +134,7 @@ def returns(
 
     return_iter = reversed(list(return_transitions))
     if max_steps is not None:
-        return_iter = itertools.islice(return_transitions, max_steps)
+        return_iter = itertools.islice(return_iter, max_steps)
 
     return return_iter
 


### PR DESCRIPTION
After our conversation, we decided that the returns function needed to be rewritten. In the new function, the number of steps to calculate (N) is determined based on γ. If we have a non-terminating MDP and N=4, we calculate the return on a trace of length 8 (2 * N) and output only the states that have at least 4 states after them:

```
--------
 -------
  ------
   -----
```

The logic to do this is still a bit fiddly, but it's simpler than what it used to be. One organizational change that simplified things is that I created a new class `ReturnTransition` which is a `Transition` *annotated* with its total return. `Transition` now has a method `add_return` which lets us do this annotation.