### PR TITLE
Organized code into Python package with a setup.cfg file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .mypy_cache
 __pycache__
 *.pyc
+*.egg-info
 
 # LaTeX files
 *.aux

--- a/default.nix
+++ b/default.nix
@@ -13,19 +13,23 @@ let
   };
 
   python-packages = ps: with ps;
-    [ # Dependencies
+    [ # Libraries
       graphviz
       matplotlib
       numpy
       pandas
       scipy
 
-      # Development
+      # Tools
       ipython
       jedi
       jupyter
-      mypy
       pytest
+
+      # Checkers
+      flake8
+      mypy
+      pylint
     ];
 
   # Applications and utilties for buidling the book

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,15 @@
+[metadata]
+name = rl-book
+version = 0.0.1
+author = Ashwin Rao, Tikhon Jelvis
+summary = Support code for "RL for Finance" book.
+requires-dist = setuptools
+
+[options]
+packages = rl
+install_requires =
+    matplotlib
+    more-itertools
+    numpy
+    pandas
+    scipy

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+import setuptools
+setuptools.setup()


### PR DESCRIPTION
This organization means that we can install our framework code as a package with pip. This isn't super important right now, but it helps with my local development tools.

For local development, we can install the package in "editable" mode from the top-level directory of the repo:

```
pip install --editable .
```

If you haven't needed to do this in the past, you don't need to do it now—everything else should continue working the same as it always has.