### PR TITLE
Added an is_terminal method to MarkovDecisionProcess.

### DIFF
--- a/rl/markov_decision_process.py
+++ b/rl/markov_decision_process.py
@@ -88,6 +88,19 @@ class MarkovDecisionProcess(ABC, Generic[S, A]):
     def actions(self, state: S) -> Iterable[A]:
         pass
 
+    def is_terminal(self, state: S) -> bool:
+        '''Is the given state a terminal state?
+
+        We cannot take any actions from a terminal state. This means
+        that a state is terminal iff `self.actions(s)` is empty.
+
+        '''
+        try:
+            next(iter(self.actions(state)))
+            return False
+        except StopIteration:
+            return True
+
     @abstractmethod
     def step(
         self,
@@ -162,8 +175,6 @@ class FiniteMarkovDecisionProcess(MarkovDecisionProcess[S, A]):
     def action_mapping(self, state: S) -> Optional[ActionMapping[A, S]]:
         return self.mapping[state]
 
-    # Note: For now, this is only available on finite MDPs; this might
-    # change in the future.
     def actions(self, state: S) -> Iterable[A]:
         '''All the actions allowed for the given state.
 


### PR DESCRIPTION
Since `MarkovProcess` has an `is_terminal` method, having an analogous method for `MarkovDecisionsProcess` makes sense—good to keep our APIs consistent in design.

The default implementation of `is_terminal(s)` checks if `actions(s)` returns an emtpy result. This can be overridden by concrete implementations of `MarkovDecisionProcess` if there are more direct and efficient ways to check whether a state is terminal.

The upside to this design is that `is_terminal` makes checking for terminal states cleaner and more explicit. The downside is that an overridden `is_terminal` could be inconsistent with `actions`, but that is an easy property to test for.