### PR TITLE
Fix seed to make tests deterministic.

### DIFF
--- a/rl/test_monte_carlo.py
+++ b/rl/test_monte_carlo.py
@@ -1,5 +1,7 @@
 import unittest
 
+import random
+
 from rl.distribution import Categorical, Choose
 from rl.function_approx import Tabular
 import rl.iterate as iterate
@@ -23,6 +25,7 @@ class FlipFlop(FiniteMarkovRewardProcess[bool]):
 
 class TestEvaluate(unittest.TestCase):
     def setUp(self):
+        random.seed(42)
         self.finite_flip_flop = FlipFlop(0.7)
 
     def test_evaluate_finite_mrp(self):

--- a/rl/test_td.py
+++ b/rl/test_td.py
@@ -1,6 +1,7 @@
 import unittest
 
 import itertools
+import random
 from typing import cast, Iterable, Iterator, Optional, Tuple
 
 from rl.distribution import Categorical, Choose
@@ -29,6 +30,8 @@ class FlipFlop(FiniteMarkovRewardProcess[bool]):
 
 class TestEvaluate(unittest.TestCase):
     def setUp(self):
+        random.seed(42)
+
         self.finite_flip_flop = FlipFlop(0.7)
 
         self.finite_mdp = FiniteMarkovDecisionProcess({


### PR DESCRIPTION
Our TD and MC tests are randomly failing because the bounds are a bit too tight. Instead of constantly fiddling with the settings and bounds for those tests, I fixed the random seed in the two modules so that they always run the same way.

This will keep our PRs from randomly failing CI.