### PR TITLE
Fixed tests for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.8"
+  - "3.7"
 
 # command to install dependencies
 install:

--- a/chapter5/chapter5.md
+++ b/chapter5/chapter5.md
@@ -73,16 +73,16 @@ When concrete classes implementing `FunctionApprox` write the `solve` method in 
 
 Any concrete class that implement this abstract class `FunctionApprox` will need to implement these four `abstractmethod`s of `FunctionApprox`, based on the specific assumptions that the concrete class makes for $f$. 
 
-Next, we write some useful methods that the concrete classes implementing `FunctionApprox` can inherit and utilize. Firstly, we write a method called `iterate_updates` that takes as input a stream (`Iterator`) of `Iterable` of $(x,y)$ pairs, and performs a series of incremental updates to the parameters $w$ (each using the `update` method), with each `update` done for each `Iterable` of $(x,y)$ pairs in the input stream `xy_seq: Iterator[Iterable[Tuple[X, float]]]`. `iterate_updates` returns an `Iterator[FunctionApprox[X]]` representing the successively updated `FunctionApprox` instances as a consequence of the repeated invocations to `update`. Note the use of the standard Python function [`itertools.accumulate`](https://docs.python.org/3/library/itertools.html#itertools.accumulate) that calculates accumulated results (including intermediate results) on an `Iterable`, based on a provided function to govern the accumulation. In the code below, the `Iterable` is the input stream `xy_seq_stream` and the function governing the accumulation is the `update` method of `FunctionApprox`.
+Next, we write some useful methods that the concrete classes implementing `FunctionApprox` can inherit and utilize. Firstly, we write a method called `iterate_updates` that takes as input a stream (`Iterator`) of `Iterable` of $(x,y)$ pairs, and performs a series of incremental updates to the parameters $w$ (each using the `update` method), with each `update` done for each `Iterable` of $(x,y)$ pairs in the input stream `xy_seq: Iterator[Iterable[Tuple[X, float]]]`. `iterate_updates` returns an `Iterator[FunctionApprox[X]]` representing the successively updated `FunctionApprox` instances as a consequence of the repeated invocations to `update`. Note the use of the `rl.iterate.accumulate` function (a wrapped version of [`itertools.accumulate`](https://docs.python.org/3/library/itertools.html#itertools.accumulate)) that calculates accumulated results (including intermediate results) on an `Iterable`, based on a provided function to govern the accumulation. In the code below, the `Iterable` is the input stream `xy_seq_stream` and the function governing the accumulation is the `update` method of `FunctionApprox`.
 
 ```python
-import itertools
+import rl.iterate as iterate
 
     def iterate_updates(
         self,
         xy_seq_stream: Iterator[Iterable[Tuple[X, float]]]
     ) -> Iterator[FunctionApprox[X]]:
-        return itertools.accumulate(
+        return iterate.accumulate(
             xy_seq_stream,
             lambda fa, xy: fa.update(xy),
             initial=self

--- a/rl/function_approx.py
+++ b/rl/function_approx.py
@@ -11,6 +11,7 @@ from operator import itemgetter
 from scipy.interpolate import splrep, BSpline
 from typing import (Callable, Dict, Generic, Iterator, Iterable, List,
                     Mapping, Optional, Sequence, Tuple, TypeVar)
+
 import rl.iterate as iterate
 
 X = TypeVar('X')
@@ -109,7 +110,7 @@ class FunctionApprox(ABC, Generic[X]):
         parameter update done for each data set of (x,y) pairs in the
         input stream of xy_seq_stream
         '''
-        return itertools.accumulate(
+        return iterate.accumulate(
             xy_seq_stream,
             lambda fa, xy: fa.update(xy),
             initial=self

--- a/rl/iterate.py
+++ b/rl/iterate.py
@@ -1,7 +1,9 @@
 '''Finding fixed points of functions using iterators.'''
-from typing import (Callable, Iterator, Optional, TypeVar)
+import itertools
+from typing import (overload, Callable, Iterable, Iterator, Optional, TypeVar)
 
 X = TypeVar('X')
+Y = TypeVar('Y')
 
 
 # It would be more efficient if you iterated in place instead of
@@ -76,3 +78,31 @@ def converged(values: Iterator[X],
         raise ValueError("converged called on an empty iterator")
 
     return result
+
+
+def accumulate(
+        iterable: Iterable[X],
+        func: Callable[[Y, X], Y],
+        *,
+        initial: Optional[Y]
+) -> Iterator[Y]:
+    '''Make an iterator that returns accumulated sums, or accumulated
+    results of other binary functions (specified via the optional func
+    argument).
+
+    If func is supplied, it should be a function of two
+    arguments. Elements of the input iterable may be any type that can
+    be accepted as arguments to func. (For example, with the default
+    operation of addition, elements may be any addable type including
+    Decimal or Fraction.)
+
+    Usually, the number of elements output matches the input
+    iterable. However, if the keyword argument initial is provided,
+    the accumulation leads off with the initial value so that the
+    output has one more element than the input iterable.
+
+    '''
+    if initial is not None:
+        iterable = itertools.chain([initial], iterable)  # type: ignore
+
+    return itertools.accumulate(iterable, func)  # type: ignore

--- a/rl/returns.py
+++ b/rl/returns.py
@@ -4,6 +4,7 @@ from typing import Iterable, Iterator, TypeVar, overload
 
 import rl.markov_process as mp
 import rl.markov_decision_process as mdp
+import rl.iterate as iterate
 
 
 S = TypeVar('S')
@@ -46,7 +47,7 @@ def returns(trace, γ, tolerance):
 
     *transitions, last_transition = list(trace)
 
-    return_steps = itertools.accumulate(
+    return_steps = iterate.accumulate(
         reversed(transitions),
         func=lambda next, curr: curr.add_return(γ, next.return_),
         initial=last_transition.add_return(γ, 0)

--- a/rl/td.py
+++ b/rl/td.py
@@ -9,6 +9,7 @@ from typing import Callable, Iterable, Iterator, TypeVar, Tuple
 from rl.function_approx import FunctionApprox
 import rl.markov_process as mp
 import rl.markov_decision_process as mdp
+import rl.iterate as iterate
 
 S = TypeVar('S')
 
@@ -35,7 +36,7 @@ def evaluate_mrp(
         return v.update([(transition.state,
                           transition.reward + γ * v(transition.next_state))])
 
-    return itertools.accumulate(transitions, step, initial=approx_0)
+    return iterate.accumulate(transitions, step, initial=approx_0)
 
 
 A = TypeVar('A')
@@ -72,4 +73,4 @@ def evaluate_mdp(
              transition.reward + γ * next_reward)
         ])
 
-    return itertools.accumulate(transitions, step, initial=approx_0)
+    return iterate.accumulate(transitions, step, initial=approx_0)

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,13 @@
-import ./. {}
+{ sources ? import nix/sources.nix
+, pkgs ? import sources.nixpkgs {}
+, python-version ? "3.8"
+}:
+let
+  versions = {
+    "3.6" = pkgs.python36;
+    "3.7" = pkgs.python37;
+    "3.8" = pkgs.python38;
+    "3.9" = pkgs.python39;
+  };
+in
+import ./. { python = versions."${python-version}"; }


### PR DESCRIPTION
We've been developing with Python 3.8 rather than 3.7, and under 3.7 our tests failed with the following error in a few places:

```
>       return itertools.accumulate(transitions, step, initial=approx_0)
E       TypeError: accumulate() takes at most 2 arguments (3 given)
```

Turns out the problem is that the `initial` argument to `itertools.accumulate` was only added in 3.8. Since we use this argument extensively in both the library code and book examples, I solved this problem by defining a version of `accumulate` in `rl/iterate.py` that has an `initial` argument:

```python
def accumulate(
        iterable: Iterable[X],
        func: Callable[[Y, X], Y],
        *,
        initial: Optional[Y]
) -> Iterator[Y]:
    # ...
```

I then replaced uses of `itertools.accumulate` in both the library code and book examples with `iterate.accumulate`:

```python
import rl.iterate as iterate
...
def evaluate_mrp(...):
    ...
    return iterate.accumulate(transitions, step, initial=approx_0)
```

I updated the text in a couple of places to add a note about this, but not sure that's the best approach. For example,

> Note the use of the standard Python function [`itertools.accumulate`](https://docs.python.org/3/library/itertools.html#itertools.accumulate)...

became:

> Note the use of the `rl.iterate.accumulate` function (a wrapped version of [`itertools.accumulate`](https://docs.python.org/3/library/itertools.html#itertools.accumulate))...

After this change, our test suite passed with Python 3.7. To catch these issues in the future, I added some code to `default.nix` that lets us open shells with Python 3.6, 3.7, 3.8 or 3.9:

```sh
nix-shell --argstr python-version '3.7'
```

I also made `3.7` the default version of Python that runs tests on every PR in this repo.