### PR TITLE
Policy Combinators

### DIFF
--- a/rl/approximate_dynamic_programming.py
+++ b/rl/approximate_dynamic_programming.py
@@ -15,9 +15,9 @@ from rl.iterate import iterate
 from rl.markov_process import (FiniteMarkovRewardProcess, MarkovRewardProcess,
                                RewardTransition, NonTerminal, State)
 from rl.markov_decision_process import (FiniteMarkovDecisionProcess,
-                                        DeterministicPolicy,
                                         MarkovDecisionProcess,
                                         StateActionMapping)
+from rl.policy import (DeterministicPolicy)
 
 S = TypeVar('S')
 A = TypeVar('A')

--- a/rl/approximate_dynamic_programming.py
+++ b/rl/approximate_dynamic_programming.py
@@ -5,11 +5,11 @@ state space.
 
 '''
 
-from typing import Callable, Iterable, Iterator, Tuple, TypeVar, Sequence, List
+from typing import Iterator, Tuple, TypeVar, Sequence, List
 from operator import itemgetter
 import numpy as np
 
-from rl.distribution import (Categorical, Distribution)
+from rl.distribution import Distribution
 from rl.function_approx import FunctionApprox
 from rl.iterate import iterate
 from rl.markov_process import (FiniteMarkovRewardProcess, MarkovRewardProcess,
@@ -17,7 +17,7 @@ from rl.markov_process import (FiniteMarkovRewardProcess, MarkovRewardProcess,
 from rl.markov_decision_process import (FiniteMarkovDecisionProcess,
                                         MarkovDecisionProcess,
                                         StateActionMapping)
-from rl.policy import (DeterministicPolicy, Policy, RandomPolicy)
+from rl.policy import DeterministicPolicy
 
 S = TypeVar('S')
 A = TypeVar('A')
@@ -27,24 +27,6 @@ A = TypeVar('A')
 ValueFunctionApprox = FunctionApprox[NonTerminal[S]]
 QValueFunctionApprox = FunctionApprox[Tuple[NonTerminal[S], A]]
 NTStateDistribution = Distribution[NonTerminal[S]]
-
-
-def optimal_q_policy(q: QValueFunctionApprox[S, A],
-                     actions: Callable[[NonTerminal[S]], Iterable[A]]) -> DeterministicPolicy[S, A]:
-    '''Return the policy that takes the optimal action at each state based
-    on the given approximation of the process's Q function.
-
-    '''
-    def optimal_action(s: NonTerminal[S]) -> A:
-        _, a = q.argmax((s, a) for a in actions(s))
-        return a
-    return DeterministicPolicy(optimal_action)
-
-def epsilon_greedy_policy(q: QValueFunctionApprox[S, A],
-                          mdp: MarkovDecisionProcess[S, A],
-                          ε: float = 0.0) -> Policy[S, A]:
-    return RandomPolicy(Categorical({mdp.explore_policy(): ε,
-                                     optimal_q_policy(q, mdp.actions): 1 - ε}))
 
 
 def extended_vf(vf: ValueFunctionApprox[S], s: State[S]) -> float:

--- a/rl/chapter11/control_utils.py
+++ b/rl/chapter11/control_utils.py
@@ -4,8 +4,8 @@ from rl.distribution import Choose
 from rl.markov_process import NonTerminal
 from rl.markov_decision_process import (
     MarkovDecisionProcess, FiniteMarkovDecisionProcess,
-    FiniteMarkovRewardProcess, FiniteDeterministicPolicy,
-    FinitePolicy, epsilon_greedy_policy)
+    FiniteMarkovRewardProcess)
+from rl.policy import FiniteDeterministicPolicy, FinitePolicy
 from rl.approximate_dynamic_programming import QValueFunctionApprox
 from rl.approximate_dynamic_programming import NTStateDistribution
 import itertools
@@ -147,7 +147,7 @@ def q_learning_learning_rate(
 ) -> Iterator[QValueFunctionApprox[S, A]]:
     return td.q_learning(
         mdp=mdp,
-        policy_from_q=lambda f, m: epsilon_greedy_policy(
+        policy_from_q=lambda f, m: mc.epsilon_greedy_policy(
             q=f,
             mdp=m,
             ϵ=epsilon
@@ -178,7 +178,7 @@ def q_learning_finite_learning_rate(
     )
     return td.q_learning(
         mdp=fmdp,
-        policy_from_q=lambda f, m: epsilon_greedy_policy(
+        policy_from_q=lambda f, m: mc.epsilon_greedy_policy(
             q=f,
             mdp=m,
             ϵ=epsilon

--- a/rl/chapter11/simple_inventory_mdp_cap.py
+++ b/rl/chapter11/simple_inventory_mdp_cap.py
@@ -33,14 +33,6 @@ initial_learning_rate: float = 0.1
 half_life: float = 10000.0
 exponent: float = 1.0
 
-glie_mc_finite_equal_wts_correctness(
-    fmdp=si_mdp,
-    gamma=gamma,
-    epsilon_as_func_of_episodes=epsilon_as_func_of_episodes,
-    episode_length_tolerance=mc_episode_length_tol,
-    num_episodes=num_episodes
-)
-
 glie_mc_finite_learning_rate_correctness(
     fmdp=si_mdp,
     initial_learning_rate=initial_learning_rate,

--- a/rl/chapter11/windy_grid.py
+++ b/rl/chapter11/windy_grid.py
@@ -4,9 +4,8 @@ from rl.chapter11.control_utils import q_learning_finite_learning_rate
 from rl.chapter11.control_utils import get_vf_and_policy_from_qvf
 from dataclasses import dataclass
 from rl.distribution import Categorical
-from rl.markov_process import NonTerminal
 from rl.markov_decision_process import FiniteMarkovDecisionProcess
-from rl.markov_decision_process import FiniteDeterministicPolicy
+from rl.policy import FiniteDeterministicPolicy
 from rl.approximate_dynamic_programming import QValueFunctionApprox
 from rl.dynamic_programming import value_iteration_result, V
 import itertools
@@ -213,7 +212,7 @@ class WindyGrid:
                                         for j in range(self.columns)))
         print()
         pol_full_dict = {
-            **{s: possible_moves[policy.deterministic_policy_map[NonTerminal(s)]]
+            **{s: possible_moves[policy.action_for[s]]
                for s in self.get_all_nt_states()},
             **{s: 'T' for s in self.terminals},
             **{s: 'X' for s in self.blocks}

--- a/rl/chapter2/simple_inventory_mrp.py
+++ b/rl/chapter2/simple_inventory_mrp.py
@@ -111,7 +111,10 @@ if __name__ == '__main__':
     from rl.markov_process import FiniteMarkovProcess
     print("Transition Map")
     print("--------------")
-    print(FiniteMarkovProcess(si_mrp.transition_map))
+    print(FiniteMarkovProcess(
+        {s.state: Categorical({s1.state: p for s1, p in v.table().items()})
+         for s, v in si_mrp.transition_map.items()}
+    ))
 
     print("Transition Reward Map")
     print("---------------------")

--- a/rl/chapter3/simple_inventory_mdp_cap.py
+++ b/rl/chapter3/simple_inventory_mdp_cap.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
 from typing import Tuple, Dict, Mapping
 from rl.markov_decision_process import FiniteMarkovDecisionProcess
-from rl.markov_decision_process import FinitePolicy
+from rl.policy import FiniteDeterministicPolicy
 from rl.markov_process import FiniteMarkovProcess, FiniteMarkovRewardProcess
-from rl.distribution import Categorical, Constant
+from rl.distribution import Categorical
 from scipy.stats import poisson
 
 
@@ -89,21 +89,25 @@ if __name__ == '__main__':
     print("------------------")
     print(si_mdp)
 
-    fdp: FinitePolicy[InventoryState, int] = FinitePolicy(
-        {InventoryState(alpha, beta):
-         Constant(user_capacity - (alpha + beta)) for alpha in
-         range(user_capacity + 1) for beta in range(user_capacity + 1 - alpha)}
+    fdp: FiniteDeterministicPolicy[InventoryState, int] = \
+        FiniteDeterministicPolicy(
+            {InventoryState(alpha, beta): user_capacity - (alpha + beta)
+             for alpha in range(user_capacity + 1)
+             for beta in range(user_capacity + 1 - alpha)}
     )
 
-    print("Policy Map")
-    print("----------")
+    print("Deterministic Policy Map")
+    print("------------------------")
     print(fdp)
 
     implied_mrp: FiniteMarkovRewardProcess[InventoryState] =\
         si_mdp.apply_finite_policy(fdp)
     print("Implied MP Transition Map")
     print("--------------")
-    print(FiniteMarkovProcess(implied_mrp.transition_map))
+    print(FiniteMarkovProcess(
+        {s.state: Categorical({s1.state: p for s1, p in v.table().items()})
+         for s, v in implied_mrp.transition_map.items()}
+    ))
 
     print("Implied MRP Transition Reward Map")
     print("---------------------")

--- a/rl/chapter3/simple_inventory_mdp_nocap.py
+++ b/rl/chapter3/simple_inventory_mdp_nocap.py
@@ -7,7 +7,7 @@ import random
 
 from rl.markov_decision_process import MarkovDecisionProcess
 from rl.markov_process import MarkovRewardProcess, NonTerminal, State
-from rl.markov_decision_process import Policy
+from rl.policy import Policy, DeterministicPolicy
 from rl.distribution import Constant, SampledDistribution
 
 
@@ -76,15 +76,16 @@ class SimpleInventoryMDPNoCap(MarkovDecisionProcess[InventoryState, int]):
         return float(count) / (time_steps * num_traces)
 
 
-class SimpleInventoryDeterministicPolicy(Policy[InventoryState, int]):
+class SimpleInventoryDeterministicPolicy(
+        DeterministicPolicy[InventoryState, int]
+):
     def __init__(self, reorder_point: int):
         self.reorder_point: int = reorder_point
 
-    def act(self, state: NonTerminal[InventoryState]) -> Constant[int]:
-        return Constant(max(
-            self.reorder_point - state.state.inventory_position(),
-            0
-        ))
+        def action_for(s: InventoryState) -> int:
+            return max(self.reorder_point - s.inventory_position(), 0)
+
+        super().__init__(action_for)
 
 
 class SimpleInventoryStochasticPolicy(Policy[InventoryState, int]):

--- a/rl/chapter4/clearance_pricing_mdp.py
+++ b/rl/chapter4/clearance_pricing_mdp.py
@@ -1,5 +1,6 @@
 from rl.markov_decision_process import (
-    FiniteMarkovDecisionProcess, FiniteMarkovRewardProcess, FinitePolicy)
+    FiniteMarkovDecisionProcess, FiniteMarkovRewardProcess)
+from rl.policy import FiniteDeterministicPolicy, FinitePolicy
 from rl.finite_horizon import WithTime
 from typing import Sequence, Tuple, Iterator
 from scipy.stats import poisson
@@ -49,13 +50,12 @@ class ClearancePricingMDP:
         return evaluate(unwrap_finite_horizon_MRP(mrp), 1.)
 
     def get_optimal_vf_and_policy(self)\
-            -> Iterator[Tuple[V[int], FinitePolicy[int, int]]]:
+            -> Iterator[Tuple[V[int], FiniteDeterministicPolicy[int, int]]]:
         return optimal_vf_and_policy(unwrap_finite_horizon_MDP(self.mdp), 1.)
 
 
 if __name__ == '__main__':
     from pprint import pprint
-    from rl.markov_process import NonTerminal
     ii = 12
     steps = 8
     pairs = [(1.0, 0.5), (0.7, 1.0), (0.5, 1.5), (0.3, 2.5)]
@@ -99,7 +99,7 @@ if __name__ == '__main__':
         pprint(vf)
         print(policy)
         prices.append(
-            [pairs[policy.deterministic_policy_map[NonTerminal(s)]][0]
+            [pairs[policy.action_for[s]][0]
              for s in range(ii + 1)])
 
     import matplotlib.pyplot as plt

--- a/rl/chapter7/asset_alloc_discrete.py
+++ b/rl/chapter7/asset_alloc_discrete.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass
 from typing import Sequence, Callable, Tuple, Iterator, List
 from rl.distribution import Distribution, SampledDistribution, Choose, Gaussian
 from rl.markov_decision_process import MarkovDecisionProcess, \
-    DeterministicPolicy, NonTerminal, State, Terminal
+    NonTerminal, State, Terminal
+from rl.policy import DeterministicPolicy
 from rl.function_approx import DNNSpec, AdamGradient, DNNApprox
 from rl.approximate_dynamic_programming import back_opt_vf_and_policy, \
     back_opt_qvf, ValueFunctionApprox, QValueFunctionApprox
@@ -228,7 +229,7 @@ if __name__ == '__main__':
     )
 
     # vf_ff: Sequence[Callable[[NonTerminal[float]], float]] = [lambda _: 1., lambda w: w.state]
-    # it_vf: Iterator[Tuple[DNNApprox[NonTerminal[float], DeterministicPolicy[float, float]]] = \
+    # it_vf: Iterator[Tuple[DNNApprox[NonTerminal[float]], DeterministicPolicy[float, float]]] = \
     #     aad.backward_induction_vf_and_pi(vf_ff)
 
     # print("Backward Induction: VF And Policy")
@@ -237,7 +238,7 @@ if __name__ == '__main__':
     # for t, (v, p) in enumerate(it_vf):
     #     print(f"Time {t:d}")
     #     print()
-    #     opt_alloc: float = p.deterministic_policy_func(NonTerminal(init_wealth))
+    #     opt_alloc: float = p.action_for(init_wealth)
     #     val: float = v(NonTerminal(init_wealth))
     #     print(f"Opt Risky Allocation = {opt_alloc:.2f}, Opt Val = {val:.3f}")
     #     print("Weights")

--- a/rl/chapter8/optimal_exercise_bi.py
+++ b/rl/chapter8/optimal_exercise_bi.py
@@ -4,7 +4,8 @@ import numpy as np
 from scipy.stats import norm
 from rl.distribution import SampledDistribution
 from rl.markov_decision_process import MarkovDecisionProcess, \
-    DeterministicPolicy, NonTerminal, State, Terminal
+    NonTerminal, State, Terminal
+from rl.policy import DeterministicPolicy
 from rl.function_approx import FunctionApprox, LinearFunctionApprox
 from rl.approximate_dynamic_programming import back_opt_vf_and_policy
 from numpy.polynomial.laguerre import lagval
@@ -237,9 +238,7 @@ if __name__ == '__main__':
 
         all_funcs.append(v)
 
-        opt_alloc: float = p.deterministic_policy_func(
-            NonTerminal(spot_price_val)
-        )
+        opt_alloc: float = p.action_for(spot_price_val)
         val: float = v(NonTerminal(spot_price_val))
         print(f"Opt Action = {opt_alloc}, Opt Val = {val:.3f}")
         print()

--- a/rl/chapter8/optimal_exercise_bin_tree.py
+++ b/rl/chapter8/optimal_exercise_bin_tree.py
@@ -3,8 +3,8 @@ from typing import Callable, Tuple, Iterator, Sequence, List
 import numpy as np
 from rl.dynamic_programming import V
 from scipy.stats import norm
-from rl.markov_decision_process import FiniteDeterministicPolicy, \
-    Terminal, NonTerminal
+from rl.markov_decision_process import Terminal, NonTerminal
+from rl.policy import FiniteDeterministicPolicy
 from rl.distribution import Constant, Categorical
 from rl.finite_horizon import optimal_vf_and_policy
 
@@ -76,7 +76,7 @@ class OptimalExerciseBinTree:
         ex_boundary: List[Tuple[float, float]] = []
         for i in range(self.num_steps + 1):
             ex_points = [j for j in range(i + 1)
-                         if policy_seq[i].deterministic_policy_map[NonTerminal(j)] and
+                         if policy_seq[i].action_for[j] and
                          self.payoff(i * dt, self.state_price(i, j)) > 0]
             if len(ex_points) > 0:
                 boundary_pt = min(ex_points) if is_call else max(ex_points)

--- a/rl/chapter9/optimal_order_execution.py
+++ b/rl/chapter9/optimal_order_execution.py
@@ -3,7 +3,8 @@ from typing import Callable, Sequence, Tuple, Iterator
 from rl.distribution import Distribution, SampledDistribution, Choose
 from rl.function_approx import FunctionApprox, LinearFunctionApprox
 from rl.markov_decision_process import MarkovDecisionProcess, \
-    DeterministicPolicy, NonTerminal, State
+    NonTerminal, State
+from rl.policy import DeterministicPolicy
 from rl.approximate_dynamic_programming import back_opt_vf_and_policy, \
     ValueFunctionApprox
 
@@ -201,15 +202,15 @@ if __name__ == '__main__':
     print("Backward Induction: VF And Policy")
     print("---------------------------------")
     print()
-    for t, (v, p) in enumerate(it_vf):
+    for t, (vf, pol) in enumerate(it_vf):
         print(f"Time {t:d}")
         print()
-        opt_sale: int = p.deterministic_policy_func(NonTerminal(state))
-        val: float = v(NonTerminal(state))
+        opt_sale: int = pol.action_for(state)
+        val: float = vf(NonTerminal(state))
         print(f"Optimal Sales = {opt_sale:d}, Opt Val = {val:.3f}")
         print()
         print("Optimal Weights below:")
-        print(v.weights.weights)
+        print(vf.weights.weights)
         print()
 
     print("Analytical Solution")

--- a/rl/dynamic_programming.py
+++ b/rl/dynamic_programming.py
@@ -8,7 +8,7 @@ from rl.iterate import converged, iterate
 from rl.markov_process import NonTerminal, State
 from rl.markov_decision_process import (FiniteMarkovDecisionProcess,
                                         FiniteMarkovRewardProcess)
-from rl.policy import (FinitePolicy, FiniteDeterministicPolicy)
+from rl.policy import FinitePolicy, FiniteDeterministicPolicy
 
 A = TypeVar('A')
 S = TypeVar('S')

--- a/rl/dynamic_programming.py
+++ b/rl/dynamic_programming.py
@@ -1,14 +1,14 @@
-import numpy as np
 import operator
 from typing import Mapping, Iterator, TypeVar, Tuple, Dict
 
+import numpy as np
+
+from rl.distribution import Categorical, Choose
 from rl.iterate import converged, iterate
 from rl.markov_process import NonTerminal, State
 from rl.markov_decision_process import (FiniteMarkovDecisionProcess,
-                                        FiniteMarkovRewardProcess,
-                                        FinitePolicy,
-                                        FiniteDeterministicPolicy)
-from rl.distribution import Categorical, Choose
+                                        FiniteMarkovRewardProcess)
+from rl.policy import (FinitePolicy, FiniteDeterministicPolicy)
 
 A = TypeVar('A')
 S = TypeVar('S')

--- a/rl/finite_horizon.py
+++ b/rl/finite_horizon.py
@@ -4,7 +4,7 @@ from itertools import groupby
 import dataclasses
 from dataclasses import dataclass
 from operator import itemgetter
-from typing import (Dict, List, Generic, Sequence, Tuple, TypeVar, Iterator)
+from typing import Dict, List, Generic, Sequence, Tuple, TypeVar, Iterator
 
 from rl.distribution import FiniteDistribution
 from rl.dynamic_programming import V, extended_vf

--- a/rl/finite_horizon.py
+++ b/rl/finite_horizon.py
@@ -11,8 +11,8 @@ from rl.dynamic_programming import V, extended_vf
 from rl.markov_process import (FiniteMarkovRewardProcess, RewardTransition,
                                StateReward, NonTerminal, Terminal, State)
 from rl.markov_decision_process import (
-    ActionMapping, FiniteMarkovDecisionProcess, FiniteDeterministicPolicy,
-    StateActionMapping)
+    ActionMapping, FiniteMarkovDecisionProcess, StateActionMapping)
+from rl.policy import FiniteDeterministicPolicy
 
 S = TypeVar('S')
 

--- a/rl/markov_decision_process.py
+++ b/rl/markov_decision_process.py
@@ -11,7 +11,7 @@ from rl.distribution import (Categorical, Distribution, FiniteDistribution)
 from rl.markov_process import (
     FiniteMarkovRewardProcess, MarkovRewardProcess, StateReward, State,
     NonTerminal, Terminal)
-from rl.policy import (FinitePolicy, Policy, UniformRandom)
+from rl.policy import FinitePolicy, Policy
 
 A = TypeVar('A')
 S = TypeVar('S')
@@ -71,13 +71,6 @@ class MarkovDecisionProcess(ABC, Generic[S, A]):
     @abstractmethod
     def actions(self, state: NonTerminal[S]) -> Iterable[A]:
         pass
-
-    def explore_policy(self) -> UniformRandom[S, A]:
-        '''The policy that selects a random valid action for each state
-        uniformly at random.
-
-        '''
-        return UniformRandom(self.actions)
 
     @abstractmethod
     def step(

--- a/rl/monte_carlo.py
+++ b/rl/monte_carlo.py
@@ -7,10 +7,10 @@ from typing import Iterable, Iterator, TypeVar, Callable
 
 from rl.approximate_dynamic_programming import (ValueFunctionApprox,
                                                 QValueFunctionApprox,
-                                                NTStateDistribution)
+                                                NTStateDistribution,
+                                                epsilon_greedy_policy)
 from rl.iterate import last
-from rl.markov_decision_process import MarkovDecisionProcess, Policy
-from rl.markov_decision_process import epsilon_greedy_policy, TransitionStep
+from rl.markov_decision_process import MarkovDecisionProcess, Policy, TransitionStep
 import rl.markov_process as mp
 from rl.returns import returns
 

--- a/rl/monte_carlo.py
+++ b/rl/monte_carlo.py
@@ -4,14 +4,15 @@ Markov Decision Processes.
 '''
 
 from typing import Iterable, Iterator, TypeVar, Callable
-import rl.markov_process as mp
+
+from rl.approximate_dynamic_programming import (ValueFunctionApprox,
+                                                QValueFunctionApprox,
+                                                NTStateDistribution)
+from rl.iterate import last
 from rl.markov_decision_process import MarkovDecisionProcess, Policy
 from rl.markov_decision_process import epsilon_greedy_policy, TransitionStep
+import rl.markov_process as mp
 from rl.returns import returns
-from rl.iterate import last
-from rl.approximate_dynamic_programming import ValueFunctionApprox
-from rl.approximate_dynamic_programming import QValueFunctionApprox
-from rl.approximate_dynamic_programming import NTStateDistribution
 
 S = TypeVar('S')
 A = TypeVar('A')
@@ -43,10 +44,12 @@ def mc_prediction(
         (returns(trace, γ, episode_length_tolerance) for trace in traces)
     f = approx_0
     yield f
+
     for episode in episodes:
         f = last(f.iterate_updates(
             [(step.state, step.return_)] for step in episode
         ))
+        assert f is not None
         yield f
 
 

--- a/rl/policy.py
+++ b/rl/policy.py
@@ -30,7 +30,7 @@ class UniformRandom(Policy[S, A]):
     valid_actions: Callable[[NonTerminal[S]], Iterable[A]]
 
     def act(self, state: NonTerminal[S]) -> Choose[A]:
-        return Choose(set(self.valid_actions(state.state)))
+        return Choose(set(self.valid_actions(state)))
 
 
 @dataclass(frozen=True)
@@ -53,10 +53,10 @@ class RandomPolicy(Policy[S, A]):
 
 @dataclass(frozen=True)
 class DeterministicPolicy(Policy[S, A]):
-    action_for: Callable[[S], A]
+    action_for: Callable[[NonTerminal[S]], A]
 
     def act(self, state: NonTerminal[S]) -> Constant[A]:
-        return Constant(self.action_for(state.state))
+        return Constant(self.action_for(state))
 
 
 class Always(DeterministicPolicy[S, A]):

--- a/rl/policy.py
+++ b/rl/policy.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import (Callable, Generic, Iterable, Mapping, TypeVar)
+
+from rl.distribution import (Choose, Constant, Distribution, FiniteDistribution)
+from rl.markov_process import (NonTerminal)
+
+A = TypeVar('A')
+S = TypeVar('S')
+
+
+class Policy(ABC, Generic[S, A]):
+    '''A policy is a function that specifies what we should do (the
+    action) at a given state of our MDP.
+
+    '''
+    @abstractmethod
+    def act(self, state: NonTerminal[S]) -> Distribution[A]:
+        '''A distribution of actions to take from the given non-terminal
+        state.
+
+        '''
+        pass
+
+
+@dataclass(frozen=True)
+class UniformRandom(Policy[S, A]):
+    valid_actions: Callable[[NonTerminal[S]], Iterable[A]]
+
+    def act(self, state: NonTerminal[S]) -> Choose[A]:
+        return Choose(set(self.valid_actions(state.state)))
+
+
+@dataclass(frozen=True)
+class RandomPolicy(Policy[S, A]):
+    '''A policy that randomly selects one of several specified policies
+    each action.
+
+    Given the right inputs, this could simulate things like ε-greedy
+    policies::
+
+        RandomPolicy()
+
+    '''
+    policy_choices: Distribution[Policy[S, A]]
+
+    def act(self, state: NonTerminal[S]) -> Distribution[A]:
+        policy: Policy[S, A] = self.policy_choices.sample()
+        return policy.act(state)
+
+
+@dataclass(frozen=True)
+class DeterministicPolicy(Policy[S, A]):
+    action_for: Callable[[S], A]
+
+    def act(self, state: NonTerminal[S]) -> Constant[A]:
+        return Constant(self.action_for(state.state))
+
+
+class Always(DeterministicPolicy[S, A]):
+    '''A constant policy: always return the same (specified) action for
+    every possible state.
+
+    '''
+    action: A
+
+    def __init__(self, action: A):
+        self.action = action
+        super().__init__(lambda _: action)
+
+
+class FinitePolicy(Policy[S, A]):
+    ''' A policy where the state and action spaces are finite.
+
+    '''
+    policy_map: Mapping[S, FiniteDistribution[A]]
+
+    def __init__(self, policy_map: Mapping[S, FiniteDistribution[A]]):
+        self.policy_map = policy_map
+
+    def __repr__(self) -> str:
+        display = ""
+        for s, d in self.policy_map.items():
+            display += f"For State {s}:\n"
+            for a, p in d:
+                display += f"  Do Action {a} with Probability {p:.3f}\n"
+        return display
+
+    def act(self, state: NonTerminal[S]) -> FiniteDistribution[A]:
+        return self.policy_map[state.state]
+
+class FiniteDeterministicPolicy(FinitePolicy[S, A]):
+    '''A deterministic policy where the state and action spaces are
+    finite.
+
+    '''
+    action_for: Mapping[S, A]
+
+    def __init__(self, action_for: Mapping[S, A]):
+        self.action_for = action_for
+        super().__init__(policy_map={s: Constant(a) for s, a in self.action_for.items()})
+
+    def __repr__(self) -> str:
+        display = ""
+        for s, a in self.action_for.items():
+            display += f"For State {s}: Do Action {a}\n"
+        return display

--- a/rl/problems/Final-Winter2021/windy_grid.py
+++ b/rl/problems/Final-Winter2021/windy_grid.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from rl.distribution import Categorical, Choose
 from rl.markov_process import NonTerminal
 from rl.markov_decision_process import FiniteMarkovDecisionProcess
-from rl.markov_decision_process import FiniteDeterministicPolicy
+from rl.policy import FiniteDeterministicPolicy
 from rl.dynamic_programming import value_iteration_result, V
 from operator import itemgetter
 
@@ -282,7 +282,7 @@ class WindyGrid:
                                         for j in range(self.columns)))
         print()
         pol_full_dict = {
-            **{s: possible_moves[policy.deterministic_policy_map[NonTerminal(s)]]
+            **{s: possible_moves[policy.action_for[s]]
                for s in self.get_all_nt_states()},
             **{s: 'T' for s in self.terminals},
             **{s: 'X' for s in self.blocks}

--- a/rl/problems/Final-Winter2021/windy_grid_outline.py
+++ b/rl/problems/Final-Winter2021/windy_grid_outline.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from rl.distribution import Categorical, Choose
 from rl.markov_process import NonTerminal
 from rl.markov_decision_process import FiniteMarkovDecisionProcess
-from rl.markov_decision_process import FiniteDeterministicPolicy
+from rl.policy import FiniteDeterministicPolicy
 from rl.dynamic_programming import value_iteration_result, V
 from operator import itemgetter
 
@@ -260,7 +260,7 @@ class WindyGrid:
                                         for j in range(self.columns)))
         print()
         pol_full_dict = {
-            **{s: possible_moves[policy.deterministic_policy_map[NonTerminal(s)]]
+            **{s: possible_moves[policy.action_for[s]]
                for s in self.get_all_nt_states()},
             **{s: 'T' for s in self.terminals},
             **{s: 'X' for s in self.blocks}

--- a/rl/problems/Midterm-Winter2021/career_optimization.py
+++ b/rl/problems/Midterm-Winter2021/career_optimization.py
@@ -1,5 +1,4 @@
 from typing import Tuple, Mapping, Dict, Sequence, Iterable
-from rl.markov_process import NonTerminal
 from rl.markov_decision_process import FiniteMarkovDecisionProcess
 from rl.dynamic_programming import value_iteration_result
 from rl.distribution import Categorical
@@ -75,7 +74,7 @@ if __name__ == '__main__':
     _, opt_det_policy = value_iteration_result(co, gamma=gamma)
     wages: Iterable[int] = range(1, co.wage_cap + 1)
     opt_actions: Mapping[int, Tuple[int, int]] = \
-        {w: opt_det_policy.deterministic_policy_map[NonTerminal(w)]
+        {w: opt_det_policy.action_for[w]
          for w in wages}
     searching: Sequence[int] = [s for _, (s, _) in opt_actions.items()]
     learning: Sequence[int] = [l for _, (_, l) in opt_actions.items()]

--- a/rl/problems/Midterm-Winter2021/grid_maze.py
+++ b/rl/problems/Midterm-Winter2021/grid_maze.py
@@ -1,5 +1,3 @@
-from typing import Tuple, Mapping
-
 SPACE = 'SPACE'
 BLOCK = 'BLOCK'
 GOAL = 'GOAL'

--- a/rl/problems/Midterm-Winter2021/midterm-p1-sol1.ipynb
+++ b/rl/problems/Midterm-Winter2021/midterm-p1-sol1.ipynb
@@ -151,8 +151,8 @@
     "from rl.iterate import converged, iterate, last\n",
     "from rl.markov_process import NonTerminal\n",
     "from rl.markov_decision_process import (FiniteMarkovDecisionProcess,\n",
-    "                                        FiniteMarkovRewardProcess,\n",
-    "                                        FinitePolicy)\n",
+    "                                        FiniteMarkovRewardProcess)\n",
+    "from rl.policy import DeterministicFinitePolicy\n",
     "from rl.dynamic_programming import value_iteration, almost_equal_vfs, greedy_policy_from_vf\n",
     "X = TypeVar('X')\n",
     "Y = TypeVar('Y')\n",
@@ -276,7 +276,7 @@
     }
    ],
    "source": [
-    "op_2.deterministic_policy_map == op.deterministic_policy_map"
+    "op_2.action_for == op.action_for""
    ]
   },
   {

--- a/rl/td.py
+++ b/rl/td.py
@@ -3,8 +3,7 @@ Markov Decision Processes.
 
 '''
 
-from typing import Callable, Iterable, Iterator, TypeVar, Tuple, Mapping, Set
-from rl.function_approx import FunctionApprox
+from typing import Callable, Iterable, Iterator, TypeVar, Set
 import rl.markov_process as mp
 from rl.markov_decision_process import MarkovDecisionProcess, Policy
 from rl.markov_decision_process import TransitionStep, NonTerminal
@@ -50,7 +49,6 @@ def td_prediction(
 
 
 A = TypeVar('A')
-QType = Mapping[S, Mapping[A, float]]
 
 
 def epsilon_greedy_action(
@@ -119,7 +117,7 @@ def glie_sarsa(
 
 
 PolicyFromQType = Callable[
-    [FunctionApprox[Tuple[S, A]], MarkovDecisionProcess[S, A]],
+    [QValueFunctionApprox[S, A], MarkovDecisionProcess[S, A]],
     Policy[S, A]
 ]
 

--- a/rl/test_approx_dp_clearance.py
+++ b/rl/test_approx_dp_clearance.py
@@ -1,20 +1,23 @@
 import unittest
-from rl.approximate_dynamic_programming import (
-    backward_evaluate_finite, backward_evaluate,
-    back_opt_vf_and_policy_finite, back_opt_vf_and_policy)
+
 import numpy as np
-from rl.distribution import Choose
-from rl.function_approx import Dynamic, Tabular
-from rl.markov_process import FiniteMarkovRewardProcess
-from rl.markov_decision_process import (FiniteMarkovDecisionProcess,
-                                        FiniteDeterministicPolicy)
-from rl.chapter4.clearance_pricing_mdp import ClearancePricingMDP
+
+from rl.distribution import (Choose)
 from rl.finite_horizon import (
     unwrap_finite_horizon_MRP, finite_horizon_MRP, evaluate,
     unwrap_finite_horizon_MDP, finite_horizon_MDP, optimal_vf_and_policy)
+from rl.function_approx import (Dynamic, Tabular)
+from rl.markov_process import (FiniteMarkovRewardProcess)
+from rl.markov_decision_process import (FiniteMarkovDecisionProcess)
+from rl.policy import (FiniteDeterministicPolicy)
+
+from rl.chapter4.clearance_pricing_mdp import ClearancePricingMDP
+
+from rl.approximate_dynamic_programming import (
+    backward_evaluate_finite, backward_evaluate,
+    back_opt_vf_and_policy_finite, back_opt_vf_and_policy)
 
 
-# @unittest.skip("Explanation (ie test is too slow)")
 class TestEvaluate(unittest.TestCase):
     def setUp(self):
         ii = 10

--- a/rl/test_approx_dp_clearance.py
+++ b/rl/test_approx_dp_clearance.py
@@ -2,14 +2,14 @@ import unittest
 
 import numpy as np
 
-from rl.distribution import (Choose)
+from rl.distribution import Choose
 from rl.finite_horizon import (
     unwrap_finite_horizon_MRP, finite_horizon_MRP, evaluate,
     unwrap_finite_horizon_MDP, finite_horizon_MDP, optimal_vf_and_policy)
-from rl.function_approx import (Dynamic, Tabular)
-from rl.markov_process import (FiniteMarkovRewardProcess)
-from rl.markov_decision_process import (FiniteMarkovDecisionProcess)
-from rl.policy import (FiniteDeterministicPolicy)
+from rl.function_approx import Dynamic, Tabular
+from rl.markov_process import FiniteMarkovRewardProcess
+from rl.markov_decision_process import FiniteMarkovDecisionProcess
+from rl.policy import FiniteDeterministicPolicy
 
 from rl.chapter4.clearance_pricing_mdp import ClearancePricingMDP
 

--- a/rl/test_approx_dp_inventory.py
+++ b/rl/test_approx_dp_inventory.py
@@ -1,15 +1,18 @@
+from typing import Sequence, Mapping
 import unittest
+
+import numpy as np
+
 from rl.approximate_dynamic_programming import (
     evaluate_finite_mrp, evaluate_mrp, value_iteration_finite, value_iteration)
 from rl.dynamic_programming import value_iteration_result
-from typing import Sequence, Mapping
-import numpy as np
-import rl.iterate as iterate
 from rl.distribution import Choose
 from rl.function_approx import Dynamic
-from rl.markov_process import FiniteMarkovRewardProcess
-from rl.markov_decision_process import (FiniteMarkovDecisionProcess,
-                                        FiniteDeterministicPolicy)
+import rl.iterate as iterate
+from rl.markov_process import (FiniteMarkovRewardProcess, NonTerminal)
+from rl.markov_decision_process import (FiniteMarkovDecisionProcess)
+from rl.policy import (FiniteDeterministicPolicy)
+
 from rl.chapter3.simple_inventory_mdp_cap import (InventoryState,
                                                   SimpleInventoryMDPCap)
 
@@ -42,7 +45,7 @@ class TestEvaluate(unittest.TestCase):
         self.implied_mrp: FiniteMarkovRewardProcess[InventoryState] =\
             self.si_mdp.apply_finite_policy(self.fdp)
 
-        self.states: Sequence[InventoryState] = \
+        self.states: Sequence[NonTerminal[InventoryState]] = \
             self.implied_mrp.non_terminal_states
 
     def test_evaluate_mrp(self):
@@ -60,7 +63,7 @@ class TestEvaluate(unittest.TestCase):
             ),
             done=lambda a, b: a.within(b, 1e-4)
         )
-        # print(mrp_finite_fa.values_map)
+
         mrp_vf2: np.ndarray = mrp_finite_fa.evaluate(self.states)
 
         self.assertLess(max(abs(mrp_vf1 - mrp_vf2)), 0.001)
@@ -70,7 +73,7 @@ class TestEvaluate(unittest.TestCase):
                 self.implied_mrp,
                 self.gamma,
                 fa,
-                Choose(self.states),
+                Choose(set(self.states)),
                 num_state_samples=30
             ),
             done=lambda a, b: a.within(b, 1e-4)
@@ -80,7 +83,7 @@ class TestEvaluate(unittest.TestCase):
         self.assertLess(max(abs(mrp_vf1 - mrp_vf3)), 0.001)
 
     def test_value_iteration(self):
-        mdp_map: Mapping[InventoryState, float] = value_iteration_result(
+        mdp_map: Mapping[NonTerminal[InventoryState], float] = value_iteration_result(
             self.si_mdp,
             self.gamma
         )[0]
@@ -106,7 +109,7 @@ class TestEvaluate(unittest.TestCase):
                 self.si_mdp,
                 self.gamma,
                 fa,
-                Choose(self.states),
+                Choose(set(self.states)),
                 num_state_samples=30
             ),
             done=lambda a, b: a.within(b, 1e-5)

--- a/rl/test_approx_dp_inventory.py
+++ b/rl/test_approx_dp_inventory.py
@@ -9,9 +9,9 @@ from rl.dynamic_programming import value_iteration_result
 from rl.distribution import Choose
 from rl.function_approx import Dynamic
 import rl.iterate as iterate
-from rl.markov_process import (FiniteMarkovRewardProcess, NonTerminal)
-from rl.markov_decision_process import (FiniteMarkovDecisionProcess)
-from rl.policy import (FiniteDeterministicPolicy)
+from rl.markov_process import FiniteMarkovRewardProcess, NonTerminal
+from rl.markov_decision_process import FiniteMarkovDecisionProcess
+from rl.policy import FiniteDeterministicPolicy
 
 from rl.chapter3.simple_inventory_mdp_cap import (InventoryState,
                                                   SimpleInventoryMDPCap)

--- a/rl/test_finite_horizon.py
+++ b/rl/test_finite_horizon.py
@@ -1,8 +1,9 @@
+from typing import Mapping, Sequence
 import unittest
 
 import dataclasses
 
-from rl.distribution import Categorical, Constant
+from rl.distribution import Categorical
 import rl.test_distribution as distribution
 from rl.markov_process import FiniteMarkovRewardProcess
 from rl.markov_decision_process import (ActionMapping,
@@ -66,7 +67,7 @@ class TestFiniteMRP(unittest.TestCase):
     def test_unwrap_finite_horizon_MRP(self):
         finite = finite_horizon_MRP(self.finite_flip_flop, 10)
 
-        def transition_for(time):
+        def transition_for(_):
             return {
                 True: Categorical({
                     (NonTerminal(True), 1.0): 0.3,
@@ -217,9 +218,9 @@ class TestFiniteMDP(unittest.TestCase):
     def test_optimal_policy(self):
         finite = finite_horizon_MDP(self.finite_flip_flop, limit=10)
         steps = unwrap_finite_horizon_MDP(finite)
-        *v_ps, (v, p) = optimal_vf_and_policy(steps, gamma=1)
+        *v_ps, (_, p) = optimal_vf_and_policy(steps, gamma=1)
 
-        for _, a in p.deterministic_policy_map.items():
+        for _, a in p.action_for.items():
             self.assertEqual(a, False)
 
         self.assertAlmostEqual(v_ps[0][0][NonTerminal(True)], 17)

--- a/rl/test_td.py
+++ b/rl/test_td.py
@@ -12,6 +12,7 @@ import rl.markov_process as mp
 from rl.markov_decision_process import FiniteMarkovDecisionProcess
 import rl.markov_decision_process as mdp
 import rl.td as td
+from rl.policy import FinitePolicy
 
 
 class FlipFlop(FiniteMarkovRewardProcess[bool]):
@@ -89,8 +90,8 @@ class TestEvaluate(unittest.TestCase):
             count_to_weight_func=lambda _: 0.1
         )
 
-        uniform_policy: mdp.FinitePolicy[bool, bool] =\
-            mdp.FinitePolicy({
+        uniform_policy: FinitePolicy[bool, bool] =\
+            FinitePolicy({
                 s.state: Choose(set(self.finite_mdp.actions(s)))
                 for s in self.finite_mdp.non_terminal_states
             })


### PR DESCRIPTION
Defined some new policy types that we can use to build more complex policies out of smaller ones. (These kinds of constructs are often called "combinators".)

In particular, we can create an ε-greedy policy by combining an explore policy and an exploit (optimal Q value) policy:

``` python
def epsilon_greedy_policy(q: QValueFunctionApprox[S, A],
                          mdp: MarkovDecisionProcess[S, A],
                          ε: float = 0.0) -> Policy[S, A]:
    return RandomPolicy(Categorical({mdp.explore_policy(): ε,
                                     optimal_q_policy(q, mdp.actions): 1 - ε}))
```

To support this, I moved the Q-value argmax logic into a dedicated function:

``` python
def optimal_q_policy(q: QValueFunctionApprox[S, A],
                     actions: Callable[[NonTerminal[S]], Iterable[A]]) -> DeterministicPolicy[S, A]:
    '''Return the policy that takes the optimal action at each state based
    on the given approximation of the process's Q function.

    '''
    def optimal_action(s: NonTerminal[S]) -> A:
        _, a = q.argmax((s, a) for a in actions(s))
        return a
    return DeterministicPolicy(optimal_action)
```

I also defined a method on the `MarkovDecisionProcess` class to create the exploration policy using the new `UniformRandom` policy class:

``` python
    def explore_policy(self) -> UniformRandom[S, A]:
        '''The policy that selects a random valid action for each state
        uniformly at random.

        '''
        return UniformRandom(self.actions)
```

Having combinators like this makes our policy definitions a bit more modular and, hopefully, easier to work with.