### PR TITLE
Added Range and changed the behavior of Choose in rl.distribution

### DIFF
--- a/chapter10/chapter10.md
+++ b/chapter10/chapter10.md
@@ -280,7 +280,7 @@ from itertools import islice
 from pprint import pprint
 
 traces: Iterable[Iterable[TransitionStep[S]]] = \
-        mrp.reward_traces(Choose(set(si_mrp.non_terminal_states)))
+        mrp.reward_traces(Choose(si_mrp.non_terminal_states))
 it: Iterator[ValueFunctionApprox[InventoryState]] = mc_prediction(
     traces=traces,
     approx_0=Tabular(),
@@ -396,7 +396,7 @@ def mrp_episodes_stream(
 def fmrp_episodes_stream(
     fmrp: FiniteMarkovRewardProcess[S]
 ) -> Iterable[Iterable[TransitionStep[S]]]:
-    return mrp_episodes_stream(fmrp, Choose(set(fmrp.non_terminal_states)))
+    return mrp_episodes_stream(fmrp, Choose(fmrp.non_terminal_states))
 
 def unit_experiences_from_episodes(
     episodes: Iterable[Iterable[TransitionStep[S]]],

--- a/chapter11/chapter11.md
+++ b/chapter11/chapter11.md
@@ -303,7 +303,7 @@ learning_rate_func: Callable[[int], float] = learning_rate_schedule(
 )
 qvfs: Iterator[QValueFunctionApprox[InventoryState, int] = glie_mc_control(
     mdp=si_mdp,
-    states=Choose(set(si_mdp.non_terminal_states)),
+    states=Choose(si_mdp.non_terminal_states),
     approx_0=Tabular(
         values_map=initial_qvf_dict,
         count_to_weight_func=learning_rate_func
@@ -504,7 +504,7 @@ learning_rate_func: Callable[[int], float] = learning_rate_schedule(
 )
 qvfs: Iterator[QValueFunctionApprox[InventoryState, int]] = glie_sarsa(
     mdp=si_mdp,
-    states=Choose(set(si_mdp.non_terminal_states)),
+    states=Choose(si_mdp.non_terminal_states),
     approx_0=Tabular(
         values_map=initial_qvf_dict,
         count_to_weight_func=learning_rate_func

--- a/chapter3/chapter3.md
+++ b/chapter3/chapter3.md
@@ -154,7 +154,7 @@ class UniformPolicy(Policy[S, A]):
     valid_actions: Callable[[S], Iterable[A]]
 
     def act(self, state: NonTerminal[S]) -> Choose[A]:
-        return Choose(set(self.valid_actions(state.state)))
+        return Choose(self.valid_actions(state.state))
 ```
 
 The above code is in the file [rl/policy.py](https://github.com/TikhonJelvis/RL-book/blob/master/rl/policy.py).

--- a/chapter4/chapter4.md
+++ b/chapter4/chapter4.md
@@ -459,7 +459,7 @@ def policy_iteration(
 
     v_0: V[S] = {s: 0.0 for s in mdp.non_terminal_states}
     pi_0: FinitePolicy[S, A] = FinitePolicy(
-        {s.state: Choose(set(mdp.actions(s))) for s in mdp.non_terminal_states}
+        {s.state: Choose(mdp.actions(s)) for s in mdp.non_terminal_states}
     )
     return iterate(update, (v_0, pi_0))
 

--- a/chapter7/chapter7.md
+++ b/chapter7/chapter7.md
@@ -468,7 +468,7 @@ class AssetAllocDiscrete:
         return len(self.risky_return_distributions)
 
     def uniform_actions(self) -> Choose[float]:
-        return Choose(set(self.risky_alloc_choices))
+        return Choose(self.risky_alloc_choices)
 
     def get_mdp(self, t: int) -> MarkovDecisionProcess[float, float]:
         distr: Distribution[float] = self.risky_return_distributions[t]

--- a/chapter9/chapter9.md
+++ b/chapter9/chapter9.md
@@ -431,7 +431,7 @@ The two key things we need to perform the backward induction are:
             price: float = self.initial_price_distribution.sample()
             rem: int = self.shares
             for i in range(t):
-                sell: int = Choose(set(range(rem + 1))).sample()
+                sell: int = Choose(range(rem + 1)).sample()
                 price = self.price_dynamics[i](PriceAndShares(
                     price=price,
                     shares=rem

--- a/rl/chapter10/prediction_utils.py
+++ b/rl/chapter10/prediction_utils.py
@@ -30,7 +30,7 @@ def mrp_episodes_stream(
 def fmrp_episodes_stream(
     fmrp: FiniteMarkovRewardProcess[S]
 ) -> Iterable[Iterable[TransitionStep[S]]]:
-    return mrp_episodes_stream(fmrp, Choose(set(fmrp.non_terminal_states)))
+    return mrp_episodes_stream(fmrp, Choose(fmrp.non_terminal_states))
 
 
 def mc_finite_prediction_equal_wts(
@@ -370,7 +370,7 @@ def compare_td_and_mc(
     sample_episodes: int = 1000
     td_episode_length: int = int(round(sum(
         len(list(returns(
-            trace=fmrp.simulate_reward(Choose(set(states))),
+            trace=fmrp.simulate_reward(Choose(states)),
             γ=gamma,
             tolerance=mc_episode_length_tol
         ))) for _ in range(sample_episodes)

--- a/rl/chapter10/simple_inventory_mrp_func_approx.py
+++ b/rl/chapter10/simple_inventory_mrp_func_approx.py
@@ -68,7 +68,7 @@ td_func_approx: LinearFunctionApprox[NonTerminal[InventoryState]] = \
 it_mc: Iterable[ValueFunctionApprox[InventoryState]] = \
     mc_prediction_learning_rate(
         mrp=si_mrp,
-        start_state_distribution=Choose(set(nt_states)),
+        start_state_distribution=Choose(nt_states),
         gamma=gamma,
         episode_length_tolerance=mc_episode_length_tol,
         initial_func_approx=mc_func_approx
@@ -77,7 +77,7 @@ it_mc: Iterable[ValueFunctionApprox[InventoryState]] = \
 it_td: Iterable[ValueFunctionApprox[InventoryState]] = \
     td_prediction_learning_rate(
         mrp=si_mrp,
-        start_state_distribution=Choose(set(nt_states)),
+        start_state_distribution=Choose(nt_states),
         gamma=gamma,
         episode_length=td_episode_length,
         initial_func_approx=td_func_approx

--- a/rl/chapter11/control_utils.py
+++ b/rl/chapter11/control_utils.py
@@ -33,7 +33,7 @@ def glie_mc_finite_control_equal_wts(
     }
     return mc.glie_mc_control(
         mdp=fmdp,
-        states=Choose(set(fmdp.non_terminal_states)),
+        states=Choose(fmdp.non_terminal_states),
         approx_0=Tabular(values_map=initial_qvf_dict),
         γ=gamma,
         ϵ_as_func_of_episodes=epsilon_as_func_of_episodes,
@@ -78,7 +78,7 @@ def glie_mc_finite_control_learning_rate(
     )
     return mc.glie_mc_control(
         mdp=fmdp,
-        states=Choose(set(fmdp.non_terminal_states)),
+        states=Choose(fmdp.non_terminal_states),
         approx_0=Tabular(
             values_map=initial_qvf_dict,
             count_to_weight_func=learning_rate_func
@@ -126,7 +126,7 @@ def glie_sarsa_finite_learning_rate(
     )
     return td.glie_sarsa(
         mdp=fmdp,
-        states=Choose(set(fmdp.non_terminal_states)),
+        states=Choose(fmdp.non_terminal_states),
         approx_0=Tabular(
             values_map=initial_qvf_dict,
             count_to_weight_func=learning_rate_func
@@ -183,7 +183,7 @@ def q_learning_finite_learning_rate(
             mdp=m,
             ϵ=epsilon
         ),
-        states=Choose(set(fmdp.non_terminal_states)),
+        states=Choose(fmdp.non_terminal_states),
         approx_0=Tabular(
             values_map=initial_qvf_dict,
             count_to_weight_func=learning_rate_func
@@ -423,13 +423,13 @@ def compare_mc_sarsa_ql(
     sample_episodes: int = 1000
     uniform_policy: FinitePolicy[S, A] = \
         FinitePolicy(
-            {s.state: Choose(set(fmdp.actions(s))) for s in states}
+            {s.state: Choose(fmdp.actions(s)) for s in states}
     )
     fmrp: FiniteMarkovRewardProcess[S] = \
         fmdp.apply_finite_policy(uniform_policy)
     td_episode_length: int = int(round(sum(
         len(list(returns(
-            trace=fmrp.simulate_reward(Choose(set(states))),
+            trace=fmrp.simulate_reward(Choose(states)),
             γ=gamma,
             tolerance=mc_episode_length_tol
         ))) for _ in range(sample_episodes)

--- a/rl/chapter7/asset_alloc_discrete.py
+++ b/rl/chapter7/asset_alloc_discrete.py
@@ -25,7 +25,7 @@ class AssetAllocDiscrete:
         return len(self.risky_return_distributions)
 
     def uniform_actions(self) -> Choose[float]:
-        return Choose(set(self.risky_alloc_choices))
+        return Choose(self.risky_alloc_choices)
 
     def get_mdp(self, t: int) -> MarkovDecisionProcess[float, float]:
         """

--- a/rl/chapter9/optimal_order_execution.py
+++ b/rl/chapter9/optimal_order_execution.py
@@ -116,7 +116,7 @@ class OptimalOrderExecution:
             price: float = self.initial_price_distribution.sample()
             rem: int = self.shares
             for i in range(t):
-                sell: int = Choose(set(range(rem + 1))).sample()
+                sell: int = Choose(range(rem + 1)).sample()
                 price = self.price_dynamics[i](PriceAndShares(
                     price=price,
                     shares=rem

--- a/rl/dynamic_programming.py
+++ b/rl/dynamic_programming.py
@@ -111,7 +111,7 @@ def policy_iteration(
 
     v_0: V[S] = {s: 0.0 for s in mdp.non_terminal_states}
     pi_0: FinitePolicy[S, A] = FinitePolicy(
-        {s.state: Choose(set(mdp.actions(s))) for s in mdp.non_terminal_states}
+        {s.state: Choose(mdp.actions(s)) for s in mdp.non_terminal_states}
     )
     return iterate(update, (v_0, pi_0))
 

--- a/rl/policy.py
+++ b/rl/policy.py
@@ -30,7 +30,7 @@ class UniformPolicy(Policy[S, A]):
     valid_actions: Callable[[S], Iterable[A]]
 
     def act(self, state: NonTerminal[S]) -> Choose[A]:
-        return Choose(set(self.valid_actions(state.state)))
+        return Choose(self.valid_actions(state.state))
 
 
 @dataclass(frozen=True)

--- a/rl/test_approx_dp_clearance.py
+++ b/rl/test_approx_dp_clearance.py
@@ -56,7 +56,7 @@ class TestEvaluate(unittest.TestCase):
         states = self.single_step_mrp.non_terminal_states
         fa_dynamic = Dynamic({s: 0.0 for s in states})
         fa_tabular = Tabular()
-        distribution = Choose(set(states))
+        distribution = Choose(states)
         approx_vf_finite = backward_evaluate_finite(
             [(self.mrp_seq[i], fa_dynamic) for i in range(self.steps)],
             1.
@@ -86,7 +86,7 @@ class TestEvaluate(unittest.TestCase):
         states = self.single_step_mdp.non_terminal_states
         fa_dynamic = Dynamic({s: 0.0 for s in states})
         fa_tabular = Tabular()
-        distribution = Choose(set(states))
+        distribution = Choose(states)
         approx_vpstar_finite = back_opt_vf_and_policy_finite(
             [(self.mdp_seq[i], fa_dynamic) for i in range(self.steps)],
             1.

--- a/rl/test_approx_dp_inventory.py
+++ b/rl/test_approx_dp_inventory.py
@@ -73,7 +73,7 @@ class TestEvaluate(unittest.TestCase):
                 self.implied_mrp,
                 self.gamma,
                 fa,
-                Choose(set(self.states)),
+                Choose(self.states),
                 num_state_samples=30
             ),
             done=lambda a, b: a.within(b, 1e-4)
@@ -109,7 +109,7 @@ class TestEvaluate(unittest.TestCase):
                 self.si_mdp,
                 self.gamma,
                 fa,
-                Choose(set(self.states)),
+                Choose(self.states),
                 num_state_samples=30
             ),
             done=lambda a, b: a.within(b, 1e-5)

--- a/rl/test_approximate_dynamic_programming.py
+++ b/rl/test_approximate_dynamic_programming.py
@@ -56,7 +56,7 @@ class TestEvaluate(unittest.TestCase):
                 γ=0.99,
                 approx_0=start,
                 non_terminal_states_distribution=Choose(
-                    set(self.finite_flip_flop.non_terminal_states)
+                    self.finite_flip_flop.non_terminal_states
                 ),
                 num_state_samples=5
             ),

--- a/rl/test_distribution.py
+++ b/rl/test_distribution.py
@@ -21,7 +21,7 @@ def assert_almost_equal(test_case, dist_a, dist_b):
 
 class TestDistribution(unittest.TestCase):
     def setUp(self):
-        self.finite = Choose(set(range(0, 6)))
+        self.finite = Choose(range(0, 6))
         self.sampled = SampledDistribution(
             lambda: self.finite.sample(),
             100000

--- a/rl/test_distribution.py
+++ b/rl/test_distribution.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import unittest
 
 from rl.distribution import (Bernoulli, Categorical, Choose, Constant,
@@ -113,6 +114,7 @@ class TestChoose(unittest.TestCase):
     def setUp(self):
         self.one = Choose({1})
         self.six = Choose({1, 2, 3, 4, 5, 6})
+        self.repeated = Choose([1,1,1,2])
 
     def test_choose(self):
         assert_almost_equal(self, self.one, Constant(1))
@@ -123,6 +125,19 @@ class TestChoose(unittest.TestCase):
         assert_almost_equal(self, self.six, categorical_six)
         self.assertAlmostEqual(self.six.probability(1), 1/6)
         self.assertAlmostEqual(self.six.probability(0), 0.)
+
+    def test_repeated(self):
+        counts = Counter(self.repeated.sample_n(1000))
+        self.assertLess(abs(counts[1] - 750), 50)
+        self.assertLess(abs(counts[2] - 250), 50)
+
+        table = self.repeated.table()
+        self.assertAlmostEqual(table[1], 0.75)
+        self.assertAlmostEqual(table[2], 0.25)
+
+        counts = Counter(self.repeated.sample_n(1000))
+        self.assertLess(abs(counts[1] - 750), 50)
+        self.assertLess(abs(counts[2] - 250), 50)
 
 
 class TestCategorical(unittest.TestCase):

--- a/rl/test_td.py
+++ b/rl/test_td.py
@@ -92,13 +92,13 @@ class TestEvaluate(unittest.TestCase):
 
         uniform_policy: FinitePolicy[bool, bool] =\
             FinitePolicy({
-                s.state: Choose(set(self.finite_mdp.actions(s)))
+                s.state: Choose(self.finite_mdp.actions(s))
                 for s in self.finite_mdp.non_terminal_states
             })
 
         transitions: Iterable[mdp.TransitionStep[bool, bool]] =\
             self.finite_mdp.simulate_actions(
-                Choose(set(self.finite_mdp.non_terminal_states)),
+                Choose(self.finite_mdp.non_terminal_states),
                 uniform_policy
             )
 


### PR DESCRIPTION
Two changes to support our experience replay code:

  1. `Choose` now chooses uniformly at random from a *list* of options rather than a *set*. This means that if a list has multiple elements, the probability of choosing those elements is higher.
  2. Added a new `Range` distribution that samples integers uniformly at random from a given range.