### PR TITLE
Switched code font so that Unicode symbols work in code blocks

### DIFF
--- a/templates/latex.template
+++ b/templates/latex.template
@@ -57,7 +57,7 @@
 % see e.g. the example of Kieran Healy:
 %% \setromanfont[Mapping=tex-text,Numbers=OldStyle]{Minion Pro} 
 %% \setsansfont[Mapping=tex-text]{Minion Pro} 
-%% \setmonofont[Mapping=tex-text,Scale=0.8]{Pragmata}
+\setmonofont[Mapping=tex-text,Scale=0.8]{DejaVu Sans Mono}
 
 % Heading styles:
 % These commands keep the koma system from making stupid sans serif section headings


### PR DESCRIPTION
I remember we ran into some problems with missing Unicode symbols in the past. I didn't know what was going on at the time, but now I've figured out that it's a code issue. I switched the font to *Deja Vu Sans Mono*—same font I use for programming—so now Unicode symbols should generally work in code blocks.

No need to change existing code samples necessarily (some people still find non-ASCII symbols hard to type :/), but if you do want to use any non-ASCII characters, they should now work correctly.