### PR TITLE
Fix missing Deja Vu font issue on macOS

### DIFF
--- a/bin/to-pdf
+++ b/bin/to-pdf
@@ -2,6 +2,13 @@
 
 book=0
 
+if [[ -z "$DEJA_VU_DIRECTORY" ]]
+then
+    echo "DEJA_VU_DIRECTORY variable not set."
+    echo "Try restarting your Nix shell."
+    exit 1
+fi
+
 if [[ $# -eq 0 ]]
 then
     book=1

--- a/default.nix
+++ b/default.nix
@@ -66,4 +66,6 @@ pkgs.stdenv.mkDerivation {
   FONTCONFIG_FILE = pkgs.makeFontsConf {
     fontDirectories = fonts;
   };
+
+  DEJA_VU_DIRECTORY = "${pkgs.dejavu_fonts}/share/fonts/truetype/";
 }

--- a/templates/latex.template
+++ b/templates/latex.template
@@ -5,12 +5,12 @@
 \usepackage{fontspec,xltxtra,xunicode}
 % fontspec means we can specify pretty much any font.
 % Because we are using XeTeX material,
-% this template needs to be called with the `--xetex` flag. 
+% this template needs to be called with the `--xetex` flag.
 
 
-% Symbols: 
-% Pandoc imports the extensive `amsmath` collection of symbols 
-% for typesetting ordinary math.  
+% Symbols:
+% Pandoc imports the extensive `amsmath` collection of symbols
+% for typesetting ordinary math.
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{bm}
@@ -30,9 +30,9 @@
 \theoremstyle{remark}
 \newtheorem*{remark}{Remark}
 
-% `babel`: 
-% The `babel` package, among other things, lets you determine what 
-% language you are using in a given stretch of text, so that typesetting 
+% `babel`:
+% The `babel` package, among other things, lets you determine what
+% language you are using in a given stretch of text, so that typesetting
 % will go well. Here we specify that mostly, we are speaking English:
 \usepackage[english]{babel}
 
@@ -53,11 +53,40 @@
 % Font:
 \setmainfont{TeX Gyre Pagella}
 
+%% On macOS, we need to reference fonts installed by Nix via their
+%% path.
+%%
+%% The nix-shell for this project puts that path into the
+%% DEJA_VU_DIRECTORY environment variable, which we can read with
+%% \CatchFileDef
+%%
+%% See: https://tex.stackexchange.com/questions/62010/can-i-access-system-environment-variables-from-latex-for-instance-home
+\usepackage{xparse}
+\ExplSyntaxOn
+\NewDocumentCommand{\getenv}{om}
+ {
+  \sys_get_shell:nnN { kpsewhich ~ --var-value ~ #2 } { } \l_tmpa_tl
+  \tl_trim_spaces:N \l_tmpa_tl
+  \IfNoValueTF { #1 }
+   {
+    \tl_use:N \l_tmpa_tl
+   }
+   {
+    \tl_set_eq:NN #1 \l_tmpa_tl
+   }
+ }
+\ExplSyntaxOff
+
 % Properly one should specify a sanserif font and a monospace font
 % see e.g. the example of Kieran Healy:
-%% \setromanfont[Mapping=tex-text,Numbers=OldStyle]{Minion Pro} 
-%% \setsansfont[Mapping=tex-text]{Minion Pro} 
-\setmonofont[Mapping=tex-text,Scale=0.8]{DejaVu Sans Mono}
+%% \setromanfont[Mapping=tex-text,Numbers=OldStyle]{Minion Pro}
+%% \setsansfont[Mapping=tex-text]{Minion Pro}
+\getenv[\DEJAVU]{DEJA_VU_DIRECTORY}
+\setmonofont{DejaVuSansMono}[
+  Mapping=tex-text,
+  Path=\DEJAVU,
+  Extension=.ttf,
+  Scale=0.8]
 
 % Heading styles:
 % These commands keep the koma system from making stupid sans serif section headings
@@ -67,16 +96,16 @@
 
 
 
-% I'm puzzled why I have this foonote speciality, 
+% I'm puzzled why I have this foonote speciality,
 % I wonder if it's part of my problem I've been having, but wont look
-% into it now. 
-\usepackage[flushmargin]{footmisc} 
+% into it now.
+\usepackage[flushmargin]{footmisc}
 % \usepackage[hang,flushmargin]{footmisc}
 
 % Paragraph format:
 % Pandoc prefers unindented paragraphs in the European style:
 %% \setlength{\parindent}{0pt}
-%  ... with paragraph breaks marked by a slight lengthening of 
+%  ... with paragraph breaks marked by a slight lengthening of
 % the space between paragraphs:
 %% \setlength{\parskip}{6pt plus 2pt minus 1pt}
 
@@ -84,18 +113,18 @@
 \pagestyle{plain}
 
 % Footnotes
-% if you have code in your footnotes, the million macro march 
+% if you have code in your footnotes, the million macro march
 % kind of bumps into itself.
-% Pandoc, having just rendered your text into LaTeX, 
-% knows whether the 'variable' `verbatim-in-note` is True, and 
+% Pandoc, having just rendered your text into LaTeX,
+% knows whether the 'variable' `verbatim-in-note` is True, and
 % If it is, it asks for a  LaTeX package that solves the dilemma:
 $if(verbatim-in-note)$
 \usepackage{fancyvrb}
 $endif$
 
-% Lists formatting: 
-% note sure what 'fancy enums' are; something to do with lists, 
-% as the further comment suggests: 
+% Lists formatting:
+% note sure what 'fancy enums' are; something to do with lists,
+% as the further comment suggests:
 $if(fancy-enums)$
 % -- Redefine labelwidth for lists; otherwise, the enumerate package will cause
 % -- markers to extend beyond the left margin.
@@ -107,17 +136,17 @@ $if(fancy-enums)$
 $endif$
 
 
-% Table formatting: 
-% What if you make a table? -- Pandoc knows, of course, and 
-% then declares that its  variable `table` is True and 
-% imports a table package suitable to its pleasantly simple tables. 
-% Needless to say infinitely   complicated tables are possible in 
+% Table formatting:
+% What if you make a table? -- Pandoc knows, of course, and
+% then declares that its  variable `table` is True and
+% imports a table package suitable to its pleasantly simple tables.
+% Needless to say infinitely   complicated tables are possible in
 % LaTeX with suitable packages. We are spared the temptation:
 
 $if(tables)$
 \usepackage{array}
 
-% Continuing on the topic of tables ... (we havent reached `endif`). 
+% Continuing on the topic of tables ... (we havent reached `endif`).
 % The commented out line below is in the default pandoc  latex.template.
 % Some unpleasantness with table formatting must be corrected.
 
@@ -129,8 +158,8 @@ $endif$
 
 
 % Subscripts:
-% Pandoc remembers whether you used subscripts, assigning True to 
-% its `subscript` variable 
+% Pandoc remembers whether you used subscripts, assigning True to
+% its `subscript` variable
 % It then needs to adopt a default with an incantation like this:
 $if(subscript)$
 \newcommand{\textsubscr}[1]{\ensuremath{_{\scriptsize\textrm{#1}}}}
@@ -139,13 +168,13 @@ $endif$
 
 % Web-style links:
 
-% markdown inclines us to use links, since our texts can be made into html. 
-% Why not have clickable blue links even in 
-% learned, scientific, religious, juridical, poetical and other suchlike texts? 
+% markdown inclines us to use links, since our texts can be made into html.
+% Why not have clickable blue links even in
+% learned, scientific, religious, juridical, poetical and other suchlike texts?
 % Never mind that they have been proven to destroy the nervous system!
 
-% First, what about the fact that links like http://example.com are 
-% technically code and thus must not be broken across lines? 
+% First, what about the fact that links like http://example.com are
+% technically code and thus must not be broken across lines?
 % [breaklinks=true] to the rescue!
 
 % Nowadays LaTeX can handle all of this with another half million macros:
@@ -162,10 +191,10 @@ $endif$
 
 
 
-% Images. 
+% Images.
 % In ye olde LaTeX one could only import a limited range of image
 % types, e.g. the forgotten .eps files.  Or else one simply drew the image with suitable
-% commands and drawing packages.  Today we want to import .jpg files we make with 
+% commands and drawing packages.  Today we want to import .jpg files we make with
 % our smart phones or whatever:
 
 $if(graphics)$
@@ -189,8 +218,8 @@ $else$
 \setcounter{secnumdepth}{0}
 $endif$
 
-% Footnotes: 
-% Wait, didn't we already discuss the crisis of code in footnotes?  
+% Footnotes:
+% Wait, didn't we already discuss the crisis of code in footnotes?
 % Evidently the order of unfolding of macros required that
 % we import a package to deal with them earlier
 % and issue a command it defines now. (Or maybe that's not the reason;
@@ -294,22 +323,22 @@ $endif$
 \newcommand{\cmark}{\ding{51}}
 \newcommand{\xmark}{\ding{55}}
 
-% At last: 
+% At last:
 % The document itself!:
 
-% After filling in all these blanks above, or erasing them 
-% where they are not needed, Pandoc has finished writing the 
+% After filling in all these blanks above, or erasing them
+% where they are not needed, Pandoc has finished writing the
 % famous LaTeX *preamble* for your document.
 % Now comes the all-important command \begin{document}
 % which as you can see, will be paired with an \end{document} at the end.
 % Pandoc knows whether you have a title, and has already
-% specified what it is; if so, it demands that the title be rendered.  
+% specified what it is; if so, it demands that the title be rendered.
 % Pandoc knows whether you want a table of contents, you
 % specify this on the command line.
 % Then, after fiddling with alignments, there comes the real
 % business: pandoc slaps its rendering of your text in the place of
 % the variable `body`
-% It then concludes the document it has been writing. 
+% It then concludes the document it has been writing.
 
 \begin{document}
 


### PR DESCRIPTION
Turns out that we can't reference custom fonts by name on macOS. I switched the monospace font for the book to use Deja Vu Sans Mono which is automatically installed in the Nix shell and it worked on Linux, but ran into this problem on macOS.

To fix the problem, we need to refer to the font by its filepath, not its name. I did this having the Nix shell set `DEJA_VU_DIRECTORY` to the path of the installed Deja Vu fonts, then did some TeX trickery to have the generated LaTeX file read this variable and fetch the font correctly.

@coverdrive, could you give this a try on this branch? The new setup worked on my Linux machine, but I haven't tested whether this actually solves the problem on macOS. Ideally, the PDF should build exactly the same as before (running `bin/to-pdf` from a `nix-shell`) with no changes needed on your end.