### PR TITLE
Change the page dimensions and text size back for the non-TF format

### DIFF
--- a/templates/latex.template
+++ b/templates/latex.template
@@ -2,7 +2,7 @@
 $if(tf-format)$
 \documentclass[10pt]{Alon}
 $else$
-\documentclass[10pt]{scrbook}
+\documentclass[12pt]{scrbook}
 $endif$
 
 % -- We are in swanky unicode, XeTeX land, and must now import these packages:
@@ -11,9 +11,9 @@ $endif$
 % Because we are using XeTeX material,
 % this template needs to be called with the `--xetex` flag.
 
+%% disable hyperref and geometry, which interfere with Alon.cls
 \usepackage{url}
 $if(tf-format)$
-% Disable hyperref because it doesn't play well with Alon.cls
 \usepackage{nohyperref}
 $else$
 \usepackage[breaklinks=true]{hyperref}
@@ -22,6 +22,9 @@ citecolor=blue,%
 filecolor=blue,%
 linkcolor=blue,%
 urlcolor=blue}
+
+\usepackage{geometry}
+\geometry{verbose,letterpaper,tmargin=2cm,bmargin=2.5cm,lmargin=3.25cm,rmargin=3.75cm}
 $endif$
 
 % Symbols:

--- a/templates/latex.template
+++ b/templates/latex.template
@@ -2,7 +2,7 @@
 $if(tf-format)$
 \documentclass[10pt]{Alon}
 $else$
-\documentclass[12pt]{scrbook}
+\documentclass[11t]{scrbook}
 $endif$
 
 % -- We are in swanky unicode, XeTeX land, and must now import these packages:


### PR DESCRIPTION
When I added support for the custom TF CLS file, I had to disable the `geometry` package for it to work. However, this change made the default rendering (with the `scrbook` class) revert back to its normal margin sizes, which don't look great on PDF. This PR adds the `geometry` package settings back to the LaTeX template, but only if the `tf-format` variable isn't set.

I had also changed the default text size to 10pt, but since there's no point in having smaller text in the free PDF version of the book, I set this back to 12pt.