### PR TITLE
bin/to-pdf can now generate *.tex files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__
 *.egg-info
 
 # LaTeX files
+book/*/*.tex
 *.aux
 *.dvi
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__
 
 # LaTeX files
 book/*/*.tex
+book.tex
 *.aux
 *.dvi
 *.log

--- a/bin/to-pdf
+++ b/bin/to-pdf
@@ -21,10 +21,11 @@ fi
 
 run_pandoc() {
     out=$1
-    chapters="${@:2}"
+    format=$2
+    chapters="${@:3}"
 
     cd book
-    pandoc --to pdf \
+    pandoc --to "$format" \
              --output "$out" \
              --metadata chapters \
              --metadata title='Foundations of Reinforcement Learning with Applications in Finance' \
@@ -49,9 +50,17 @@ tf-format() {
     if [[ $TF_FORMAT == 1 ]]; then echo -n "${@}"; fi
 }
 
+
+format="pdf"
+if [[ $TO_TEX == 1 ]]; then format="latex"; fi
+
+extension="$format"
+if [ "$format" = "latex" ]; then extension="tex"; fi
+
+
 if [[ $book == 1 ]]
 then
-    out="$(pwd)/book.pdf"
+    out="$(pwd)/book.$extension"
 
     echo "Building $out from:"
     while read chapter
@@ -62,7 +71,7 @@ then
     # Regexp matches blank lines and comments, which we filter out
     # with grep
 
-    run_pandoc "$out" "${names[@]}"
+    run_pandoc "$out" "$format" "${names[@]}"
 else
     # Several equivalent options:
     #
@@ -73,9 +82,9 @@ else
     file=$(basename $1)
     name="${file%.*}"
     target="$name/$name.md"
-    out="${target%.*}.pdf"
+    out="${target%.*}.$extension"
 
-    echo "Converting book/$target to book/$out."
-    run_pandoc "$out" "$target"
+    echo "Converting book/$target to book/$out"
+    run_pandoc "$out" "$format" "$target"
 fi
 

--- a/book/chapter1/chapter1.md
+++ b/book/chapter1/chapter1.md
@@ -1,9 +1,5 @@
 ## Programming and Design {#sec:python .unnumbered}
 
-``` {quoteBy="Fred Brooks" quoteFrom="The Mythical Man-Month"}
-The programmer, like the poet, works only slightly removed from pure thought-stuff. He builds his castles in the air, from air, creating by exertion of the imagination. Few media of creation are so flexible, so easy to polish and rework, so readily capable of realizing grand conceptual structures.
-```
-
 Programming is creative work with few constraints: imagine something and you can probably build it—in *many* different ways. Liberating and gratifying, but also challenging. Just like starting a novel from a blank page or a painting from a blank canvas, a new program is so open that it's a bit intimidating. Where do you start? What will the system look like? How will you get it *right*? How do you split your problem up? How do you prevent your code from evolving into a complete mess?
 
 There's no easy answer. Programming is inherently iterative—we rarely get the right design at first, but we can always edit code and refactor over time. But iteration itself is not enough; just like a painter needs technique and composition, a programmer needs patterns and design.


### PR DESCRIPTION
Added an environment variable for `bin/to-pdf` to generate a TeX file rather than a PDF. This is useful for debugging as well as eventually sending the TeX file to the publisher.

To generate a TeX file rather than a PDF, you can run:

``` shell
TO_TEX=1 bin/to-pdf chapter1
```

This works for the entire book as well:

``` shell
TO_TEX=1 bin/to-pdf
```