### PR TITLE
Added .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Emacs files
 *~
 
+# macOS
+.DS_Store
+
 # Python
 .venv
 .mypy_cache


### PR DESCRIPTION
`.DS_Store` files are hidden files that macOS automatically creates in directories. It's easy to push them by accident, so I like to include them in my `.gitignore` files, but for some reason I didn't do this when I created this repo in particular.