### PR TITLE
PDF ToC Fixes

### DIFF
--- a/book/appendix1/appendix1.md
+++ b/book/appendix1/appendix1.md
@@ -1,4 +1,4 @@
-\appendix
+\startappendix
 
 ## Moment Generating Function and Its Applications {#sec:mgf-appendix}
 \index{moment generating function|(}

--- a/book/bibliography/bibliography.md
+++ b/book/bibliography/bibliography.md
@@ -1,4 +1,6 @@
 ## Bibliography {.unnumbered .unlisted}
 
+\bibheader
+
 ::: {#refs}
 :::

--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,8 @@ let
       footmisc
       titling
       xpatch
-      noto;
+      noto
+      imakeidx;
   };
 
   python-packages = ps: with ps;

--- a/default.nix
+++ b/default.nix
@@ -8,11 +8,13 @@ let
   tex-packages = {
     inherit (pkgs.texlive)
       scheme-medium
+
+      appendix
       footmisc
-      titling
-      xpatch
+      imakeidx
       noto
-      imakeidx;
+      titling
+      xpatch ;
   };
 
   python-packages = ps: with ps;

--- a/templates/latex.template
+++ b/templates/latex.template
@@ -27,8 +27,13 @@ $endif$
 
 % Indexing
 $if(index)$
+$if(tf-format)$
 \usepackage{makeidx}
 \makeindex
+$else$
+\usepackage{imakeidx}
+\makeindex[intoc]
+$endif$
 $endif$
 
 
@@ -351,7 +356,9 @@ $if(biblatex)$
 $endif$
 
 $if(index)$
+$if(tf-format)$
 \addcontentsline{toc}{fm}{Index}
+$endif$
 \printindex
 $endif$
 

--- a/templates/latex.template
+++ b/templates/latex.template
@@ -25,17 +25,18 @@ urlcolor=blue}
 \geometry{verbose,letterpaper,tmargin=2cm,bmargin=2.5cm,lmargin=3cm,rmargin=3.5cm}
 $endif$
 
-% Indexing
-$if(index)$
+% Bibliography Header
+%% The T&F format adds the bibliography to the ToC automatically, but
+%% we need to do it explicitly for our own PDF.
 $if(tf-format)$
-\usepackage{makeidx}
-\makeindex
+\newcommand{\bibheader}{}
 $else$
-\usepackage{imakeidx}
-\makeindex[intoc]
-$endif$
+\newcommand{\bibheader}{\addcontentsline{toc}{chapter}{Bibliography}}
 $endif$
 
+% Appendecies
+%% We need an \appendixpage for our version of the PDF but not for the
+%% T&F version
 $if(tf-format)$
 \newcommand{\startappendix}{\appendix}
 $else$
@@ -45,6 +46,17 @@ $else$
   \appendixpage
   \addappheadtotoc
 }
+$endif$
+
+% Index
+$if(index)$
+$if(tf-format)$
+\usepackage{makeidx}
+\makeindex
+$else$
+\usepackage{imakeidx}
+\makeindex[intoc]
+$endif$
 $endif$
 
 % Symbols:

--- a/templates/latex.template
+++ b/templates/latex.template
@@ -36,6 +36,16 @@ $else$
 $endif$
 $endif$
 
+$if(tf-format)$
+\newcommand{\startappendix}{\appendix}
+$else$
+\usepackage{appendix}
+\newcommand{\startappendix}{%
+  \appendix
+  \appendixpage
+  \addappheadtotoc
+}
+$endif$
 
 % Symbols:
 % Pandoc imports the extensive `amsmath` collection of symbols


### PR DESCRIPTION
Three fixes for our version of the PDF:

  - add index to ToC
  - add bibliography to ToC
  - add Appendices module to ToC, separate from normal modules