### PR TITLE
Update chapter1.md

### DIFF
--- a/book/chapter1/chapter1.md
+++ b/book/chapter1/chapter1.md
@@ -716,8 +716,10 @@ At each iteration, $x_{n + 1}$ gets closer to the right answer by smaller and sm
 ``` python
 def sqrt(a: float) -> float:
     x = a / 2 # initial guess
+    x_n = a
     while abs(x_n - x) > 0.01:
         x_n = (x + (a / x)) / 2
+        x = x_n
     return x_n
 ```
 
@@ -730,8 +732,10 @@ The first improvement we can make is to turn the `0.01` into an extra parameter:
 ``` python
 def sqrt(a: float, threshold: float) -> float:
     x = a / 2 # initial guess
+    x_n = a
     while abs(x_n - x) > threshold:
         x_n = (x + (a / x)) / 2
+        x = x_n
     return x_n
 ```
 
@@ -820,11 +824,11 @@ A fixed number of iterations can be useful for exploration, but we probably want
 
 ``` python
 def converge(values: Iterator[float], threshold: float) -> Iterator[float]:
-        for a, b in itertools.pairwise(values):
-            yield a
+    for a, b in itertools.pairwise(values):
+        yield a
 
-            if abs(a - b) < threshold:
-                break
+        if abs(a - b) < threshold:
+            break
 ```
 
 For older versions of Python, we'd have to implement our version of `pairwise` as well:


### PR DESCRIPTION
- L716-740: When run, the first two `sqrt` python functions give error as `x_n` is undefined, unlike the third `sqrt` code that uses generator. Therefore, I added and initialized `x_n`; `x` <- `x_n` after each of the approximation step.

- L826-831: Indentation reduced.